### PR TITLE
feat(boosts): support live boost metadata and include unknown podcast fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .env
 .lsp
 .nrepl-port
+.clojure-mcp
 age_key.txt
 decrypted_secrets
 result

--- a/src/boost_scraper/boosties.clj
+++ b/src/boost_scraper/boosties.clj
@@ -1,7 +1,8 @@
 (ns boost-scraper.boosties
-  (:require [datalevin.core :as d]
-            [boost-scraper.core :as core]
+  (:require [clojure.math :as math]
             [clojure.string :as str]
+            [datalevin.core :as d]
+            [boost-scraper.core :as core]
             [boost-scraper.reports :as reports]))
 
 (defn boosties-v1 [conn action]
@@ -116,7 +117,8 @@
    boosts))
 
 (comment
-  (require '[boost-scraper.core :as core])
+  ;; REPL scratch space
+  (require '[boost-scraper.core :as core] :reload)
   (def conn core/nodecan-conn)
 
   (boosties-v1 conn "boost")
@@ -128,7 +130,7 @@
     (str/join
      "\n"
      (for [[sender _ sent] (reverse (take 5 (boosts-by-total-amount conn)))]
-       (str sender " " (boost-scraper.reports/int-comma (clojure.math/round sent)))))
+       (str sender " " (boost-scraper.reports/int-comma (math/round sent)))))
     "\n"
     "\n"
     "Sent us the most boosts"
@@ -136,7 +138,7 @@
     (str/join
      "\n"
      (for [[sender sent] (reverse (take 5 (boosts-by-number conn)))]
-       (str sender " " (boost-scraper.reports/int-comma (clojure.math/round sent)))))
+       (str sender " " (boost-scraper.reports/int-comma (math/round sent)))))
     "\n"
     "\n"
     "Sent us the most streamed sats"
@@ -144,7 +146,7 @@
     (str/join
      "\n"
      (for [[sender _ sent] (reverse (take 5 (streams-by-total-amount conn)))]
-       (str sender " " (boost-scraper.reports/int-comma (clojure.math/round sent)))))
+       (str sender " " (boost-scraper.reports/int-comma (math/round sent)))))
     "\n"
     "\n"
     "Sent us the most streams"
@@ -152,7 +154,7 @@
     (str/join
      "\n"
      (for [[sender sent] (reverse (take 5 (streams-by-number conn)))]
-       (str sender " " (boost-scraper.reports/int-comma (clojure.math/round sent)))))))
+       (str sender " " (boost-scraper.reports/int-comma (math/round sent)))))))
 
   ;; total from boosts and streams
   (sum-of-boosts (total-v4v conn))

--- a/src/boost_scraper/db.clj
+++ b/src/boost_scraper/db.clj
@@ -24,6 +24,8 @@
    :boostagram/message {:db/valueType :db.type/string}
    :boostagram/value_msat_total {:db/valueType :db.type/long}
    :boostagram/value_sat_total {:db/valueType :db.type/long}
+   :boostagram/ts {:db/valueType :db.type/long}
+   :boostagram/time {:db/valueType :db.type/string}
    :scraper/source {:db/valueType :db.type/string}
    :boostagram/content_id {:db/valueType :db.type/string
                            ;; TODO: enable uniqueness after we're sure this is unique enough

--- a/src/boost_scraper/legacy.clj
+++ b/src/boost_scraper/legacy.clj
@@ -209,10 +209,10 @@
            "+ Unique Streamers: " (v1/int-comma streamers) "\n")))
 
 (comment
-
+  #_{:clj-kondo/ignore [:unresolved-symbol]}
   (boost-report-v2 conn #"(?i).*linux.*" (-> #inst "2024-07-01T00:00Z" (#(.getTime %)) (/ 1000)))
   (boost-report-v2 conn #"(?i).*self.*" "443250")
 
   (boost-report-v2 conn #"(?i).*linux.*" "450565")
-
+  #_{:clj-kondo/ignore [:unresolved-symbol]}
   (make-stream-summary conn #"(?i).*self.*" "443250"))

--- a/src/boost_scraper/reports.clj
+++ b/src/boost_scraper/reports.clj
@@ -6,7 +6,6 @@
             [datalevin.core :as d]))
 
 (defn get-boost-summary-for-report' [conn show-regex last-seen-timestamp]
-  #_:clj-kondo/ignore ;; FIXME: kondo doesn't like (get-else ...)?
   (d/q '[:find (d/pull ?e [:db/id
                            :invoice/identifier
                            :invoice/created_at
@@ -17,7 +16,8 @@
                            :boostagram/podcast
                            :boostagram/episode
                            :boostagram/app_name
-                           :boostagram/message])
+                           :boostagram/message
+                           :boostagram/ts])
          :in $ ?regex' ?last-seen-timestamp'
          :where
          [?e :invoice/creation_date ?creation_date]
@@ -26,8 +26,8 @@
          (not [?e :boostagram/sender_name_normalized "chrislas"])
          (not [?e :boostagram/sender_name_normalized "noblepayne"])
          [?e :boostagram/action "boost"]
-         ;; match our particular show
-         [?e :boostagram/podcast ?podcast]
+          ;; match our particular show
+         [(get-else $ ?e :boostagram/podcast "Unknown Podcast") ?podcast]
          [(get-else $ ?e :boostagram/episode "Unknown Episode") ?episode]
          (or [(re-matches ?regex' ?podcast) _]
              [(re-matches ?regex' ?episode) _])]
@@ -73,7 +73,7 @@
             (not [?e :boostagram/sender_name_normalized "breezywes"])
             ;; match our particular show
             ;; TODO: support no podcast being specified
-            [?e :boostagram/podcast ?podcast]
+            [(get-else $ ?e :boostagram/podcast "Unknown Podcast") ?podcast]
             [(get-else $ ?e :boostagram/episode "Unknown Episode") ?episode]
             (or [(re-matches ?regex' ?podcast) _]
                 [(re-matches ?regex' ?episode) _])]
@@ -120,6 +120,7 @@
                                    :boostagram/podcast
                                    :boostagram/episode
                                    :boostagram/app_name
+                                   :boostagram/ts
                                    :invoice/created_at
                                    :invoice/creation_date
                                    :invoice/identifier
@@ -236,6 +237,8 @@
                   boostagram/podcast
                   boostagram/episode
                   boostagram/app_name
+                  boostagram/ts
+                  boostagram/time
                   #_invoice/identifier
                   invoice/creation_date
                   scraper/source]} boost]
@@ -243,6 +246,9 @@
             "+ " episode "\n"
             "+ " app_name "\n"
             "+ " source "\n"
+            (when (or ts time)
+              (let [display-ts (or ts time)]
+                (str "+ at " (if (string? display-ts) display-ts (utils/format-seconds display-ts)) "\n")))
             #_("+ " identifier "\n")
             "\n"
             "+ " (utils/format-date creation_date) " (" creation_date ")" "\n"

--- a/src/boost_scraper/upstream/alby.clj
+++ b/src/boost_scraper/upstream/alby.clj
@@ -16,7 +16,7 @@
   (get-boosts [_ {:keys [token offset wait items after since] :as last_}]
     (when @upstream/scrape
       (println "Alby still going!" offset)
-      (let [offset (or offset (or (:page last_) 1))
+      (let [offset (or offset (:page last_) 1)
             query-params {:items (or items 100) :page offset}
             query-params (if after
                            (assoc query-params

--- a/src/boost_scraper/utils.clj
+++ b/src/boost_scraper/utils.clj
@@ -6,6 +6,14 @@
       (.atZone (java.time.ZoneId/of "America/Los_Angeles"))
       (.format (java.time.format.DateTimeFormatter/ofPattern "yyyy/MM/dd h:mm:ss a zzz"))))
 
+(defn format-seconds [seconds]
+  (let [hours (quot seconds 3600)
+        mins (quot (mod seconds 3600) 60)
+        secs (mod seconds 60)]
+    (if (pos? hours)
+      (format "%d:%02d:%02d" hours mins secs)
+      (format "%d:%02d" mins secs))))
+
 (defn apply-virtual
   "Returns a CompletableFuture eventually containing (apply f args)."
   [f & args]

--- a/src/boost_scraper/web.clj
+++ b/src/boost_scraper/web.clj
@@ -31,7 +31,9 @@
 ;; Routes
 (def show->regex
   {"All Shows" ".*"
+   "All Shows (+ Unknown)" ".*|Unknown Podcast"
    "LINUX Unplugged" "(?i).*unplugged.*"
+   "LINUX Unplugged (+ Unknown)" "(?i).*unplugged.*|Unknown Podcast"
    "Coder Radio" "(?i).*coder.*"
    "Self-Hosted" "(?i).*hosted.*"
    "This Week in Bitcoin" "(?i).*bitcoin.*"
@@ -68,8 +70,8 @@
              [:meta {:http-equiv "refresh", :content "60"}]
              [:title "Boosts!"]
              [:style (html/raw pico-classless)]
-             [:style (html/raw (str "div#report blockquote {padding-bottom: 0px;
-                                                           padding-top: 0px;}"))]
+             [:style (html/raw "div#report blockquote {padding-bottom: 0px;
+                                                           padding-top: 0px;}")]
              [:script {:type "text/javascript"}
               (html/raw js)]
              [:body


### PR DESCRIPTION
Adds support for live boost metadata, enabling visibility of boosts that lack standard podcast/episode fields.

Schema updates introduce ts and time fields to persist playback position metadata. Queries are adjusted to fall back to "Unknown Podcast" and "Unknown Episode" when metadata is missing, ensuring live boosts are included in results.

UI filters are extended to optionally include unknown podcast entries, and a small utility is added for formatting seconds into human-readable timestamps.

Key changes:
  - Add ts and time fields to boostagram schema
  - Include live boosts in queries via podcast fallback
  - Surface timestamp metadata in report output
  - Add dropdown options to include unknown podcasts
  - Introduce format-seconds helper for display formatting