### PR TITLE
feat: add show registry with slug-based lookup and /api/v1/show endpoint

### DIFF
--- a/src/boost_scraper/shows.clj
+++ b/src/boost_scraper/shows.clj
@@ -1,0 +1,60 @@
+(ns boost-scraper.shows
+  "Show registry with slug-based lookup.
+   Registry pattern - data-driven configuration for show matching."
+  (:require [clojure.string :as str]))
+
+(def shows
+  "Map of slug -> show configuration.
+   Uses sorted-map to preserve deterministic iteration order for UI."
+  (sorted-map
+   "all"    {:slug "all"    :name "All Shows"          :regex ".*"}
+   "lup"    {:slug "lup"    :name "LINUX Unplugged"    :regex "(?i).*unplugged.*"}
+   "launch" {:slug "launch" :name "The Launch 🚀"       :regex "(?i).*launch.*"}
+   "twib"   {:slug "twib"   :name "This Week in Bitcoin" :regex "(?i).*bitcoin.*"}
+   "ssh"    {:slug "ssh"    :name "Self-Hosted"        :regex "(?i).*hosted.*"}
+   "coder"  {:slug "coder"  :name "Coder Radio"        :regex "(?i).*coder.*"}))
+
+(defn resolve-show
+  "Resolve a show identifier (slug or name) to show config.
+   Returns nil if not found.
+   Lookup order: slug (case-insensitive), then name (case-insensitive)."
+  [id]
+  (when (seq id)
+    (let [id-normalized (str/lower-case id)]
+      (or (get shows id-normalized)
+          (some #(when (= (str/lower-case (:name %)) id-normalized) %) (vals shows))))))
+
+(defn regex-for
+  "Get regex pattern string for show identifier.
+   Handles include-unknown flag.
+   Returns nil if show not found."
+  ([id]
+   (regex-for id true))
+  ([id include-unknown?]
+   (when-let [show (resolve-show id)]
+     (let [base (:regex show)]
+       (if include-unknown?
+         (str base "|Unknown Podcast")
+         base)))))
+
+(defn slug?
+  "Check if identifier is a known slug."
+  [id]
+  (when (seq id)
+    (contains? shows (str/lower-case id))))
+
+(defn show-slugs
+  "Return all available slugs in display order."
+  []
+  (keys shows))
+
+(defn show-options
+  "Return shows for UI dropdown or API.
+   Each entry: {:slug :name :regex}"
+  ([]
+   (show-options true))
+  ([include-unknown?]
+   (for [[slug cfg] shows]
+     {:slug slug
+      :name (:name cfg)
+      :regex (regex-for slug include-unknown?)})))

--- a/src/boost_scraper/web.clj
+++ b/src/boost_scraper/web.clj
@@ -2,6 +2,7 @@
   (:require [aleph.http :as http]
             [babashka.http-client :as httpc]
             [boost-scraper.reports :as reports]
+            [boost-scraper.shows :as shows]
             [cheshire.core :as json]
             [clojure.java.io :as io]
             [clojure.math :as math]
@@ -13,6 +14,12 @@
             [reitit.ring :as ring]
             [reitit.ring.middleware.parameters]
             [reitit.ring.middleware.muuntaja :as muuntaja]))
+
+;; Routes
+(defn two-weeks-ago []
+  (let [now (/ (System/currentTimeMillis) 1000)
+        two-weeks-ago (- now (* 2 60 60 24 7))]
+    (math/round two-weeks-ago)))
 
 ;; CSS
 (def pico-classless
@@ -28,35 +35,28 @@
         (slurp (io/resource "boost_report.js")))
        "\n"))
 
-;; Routes
-(def show->regex
-  {"All Shows" ".*"
-   "All Shows (+ Unknown)" ".*|Unknown Podcast"
-   "LINUX Unplugged" "(?i).*unplugged.*"
-   "LINUX Unplugged (+ Unknown)" "(?i).*unplugged.*|Unknown Podcast"
-   "Coder Radio" "(?i).*coder.*"
-   "Self-Hosted" "(?i).*hosted.*"
-   "This Week in Bitcoin" "(?i).*bitcoin.*"
-   "The Launch 🚀" "(?i).*launch.*"})
-
-(defn two-weeks-ago []
-  (let [now (/ (System/currentTimeMillis) 1000)
-        two-weeks-ago (- now (* 2 60 60 24 7))]
-    (math/round two-weeks-ago)))
-
-;; TODO: consolidate CSS?
 (defn get-boosts [db-conn]
   (fn [request]
-    (let [{{:strs [show since json]} :params} request
+    (let [{{:strs [show since json include-unknown]} :params} request
           default-since (two-weeks-ago)
-          json-mode (= json "true")]
-      (if (and json-mode show since)
-        (let [show (re-pattern show)
+          json-mode (= json "true")
+          include-unknown (if (some? include-unknown) (= include-unknown "true") true)
+          show-regex (shows/regex-for show include-unknown)]
+      (cond
+        (and json-mode show since show-regex)
+        (let [show (re-pattern show-regex)
               since (Integer/parseInt since)
               data (reports/sort-report (reports/get-boost-summary-for-report db-conn show since))]
           {:status 200
            :headers {"content-type" "application/json"}
            :body (json/generate-string data)})
+
+        (and show (not show-regex))
+        {:status 400
+         :headers {"content-type" "application/json"}
+         :body (json/generate-string {:error (str "Invalid show: " show)})}
+
+        :else
         {:status 200
          :headers {"content-type" "text/html; charset=utf-8"}
          :body
@@ -83,21 +83,16 @@
                   [:form {:action "/boosts"}
                    [:label {:for "showselect"} "Show:"]
                    [:select#showselect {:name "show"}
-                    (for [show-option (keys show->regex)]
-                      [:option {:value (show->regex show-option)
-                                :selected (= show show-option)} show-option])]
+                    (for [show-option (shows/show-options include-unknown)]
+                      [:option {:value (:slug show-option)
+                                :selected (= (some-> show str/lower-case) (:slug show-option))} (:name show-option)])]
                    [:label {:for "since"} "Last Seen Timestamp:"]
                    [:input#since {:name "since" :type "text" :value default-since}]
                    [:input {:type "submit" :value "Get Boosts!"}]]
                   ;; Query results
-                  (let [show (re-pattern show)
+                  (let [show (re-pattern show-regex)
                         since (Integer/parseInt since)
-                        report (reports/boost-report db-conn show since)
-                        ;; hacky prototype helipad replacement
-                        #_(str/join "\n" (map #(reports/format-boost-batch-details [%])
-                                              (sort-by :invoice/creation_date
-                                                       #(compare %2 %1)
-                                                       (into [] cat (reports/get-boost-summary-for-report' db-conn show since)))))]
+                        report (reports/boost-report db-conn show since)]
                     [:div#boosts {:style {:margin-top "10px" :margin-bottom "10px"}}
                      [:div {:style {"padding" "10px"}}
                       [:button#copyMarkdown {:onClick "copyMarkdown()"} "Copy Markdown"]
@@ -113,6 +108,13 @@
 (defn routes [db-conn]
   [["/ping"
     {:get {:handler (fn [_] {:status 200 :body "pong\n"})}}]
+   ["/api/v1/shows"
+    {:get {:handler (fn [request]
+                      (let [include-unknown-param (get-in request [:params "include-unknown"])
+                            include-unknown (or (= include-unknown-param "true") (nil? include-unknown-param))]
+                        {:status 200
+                         :headers {"content-type" "application/json"}
+                         :body (json/generate-string {:shows (shows/show-options include-unknown)})}))}}]
    ["/boosts" {:get {:handler (get-boosts db-conn)}}]])
 
 (defn http-handler [db-conn]


### PR DESCRIPTION
Add data-driven show registry using sorted-map with slug identifiers.
- New shows.clj module with registry pattern
- Slug-based lookups (lup, launch, twib, etc) instead of raw regex
- ?include-unknown=true query param (default: true)
- GET /api/v1/shows endpoint for agent discovery
- Case-insensitive show matching
- Better error handling (400 for invalid show)