### PR TITLE
feat: add client state tracking for agent-based incremental fetching

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,22 +1,22 @@
 {:paths ["src" "resources"]
- :deps  {org.clojure/clojure {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}
          ;; database
-         datalevin/datalevin {:mvn/version "0.9.13"}
+        datalevin/datalevin {:mvn/version "0.9.13"}
          ;; HTTP
-         cheshire/cheshire {:mvn/version "5.13.0"}
-         org.babashka/http-client {:mvn/version "0.4.22"}
-         aleph/aleph {:mvn/version "0.8.2"}
-         metosin/reitit {:mvn/version "0.7.2"}
-         metosin/muuntaja {:mvn/version "0.6.11"}
+        cheshire/cheshire {:mvn/version "5.13.0"}
+        org.babashka/http-client {:mvn/version "0.4.22"}
+        aleph/aleph {:mvn/version "0.8.2"}
+        metosin/reitit {:mvn/version "0.7.2"}
+        metosin/muuntaja {:mvn/version "0.6.11"}
          ;; markdown and hiccup
-         com.kiranshila/cybermonday {:mvn/version "0.6.215"}
-         dev.onionpancakes/chassis {:mvn/version "1.0.365"}
+        com.kiranshila/cybermonday {:mvn/version "0.6.215"}
+        dev.onionpancakes/chassis {:mvn/version "1.0.365"}
          ;; validation
-         metosin/malli {:mvn/version "0.17.0"}
+        metosin/malli {:mvn/version "0.17.0"}
          ;; config
-         aero/aero {:mvn/version "1.1.6"}
+        aero/aero {:mvn/version "1.1.6"}
          ;; cli interface
-         org.babashka/cli {:mvn/version "0.8.60"}}
+        org.babashka/cli {:mvn/version "0.8.60"}}
  :aliases
  {:jvm-base {:jvm-opts [;; required by datalevin
                         "--add-opens=java.base/java.nio=ALL-UNNAMED"
@@ -26,4 +26,6 @@
   :neil {:project {:name com.noblepayne/lnd-boost-scraper}}
   :outdated {;; Note that it is `:deps`, not `:extra-deps`
              :deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
-             :main-opts ["-m" "antq.core"]}}}
+             :main-opts ["-m" "antq.core"]}
+  :test {:extra-paths ["test"]
+         :main-opts ["-e" "(require 'boost-scraper.api-test) (clojure.test/run-tests 'boost-scraper.api-test)"]}}}

--- a/src/boost_scraper/client_state.clj
+++ b/src/boost_scraper/client_state.clj
@@ -1,0 +1,95 @@
+(ns boost-scraper.client-state
+  "Client state tracking for agent-based incremental fetching.
+   Tracks last-seen timestamp per client+show combination."
+  (:require [datalevin.core :as d]))
+
+(defn client-state-key
+  "Generate composite key for client-state entity."
+  [client-id show-slug]
+  (str client-id ":" show-slug))
+
+(defn get-client-state
+  "Get client state for a specific client and show.
+   Returns entity map or nil if not found."
+  [conn client-id show-slug]
+  (let [key (client-state-key client-id show-slug)]
+    (d/q '[:find (pull ?e [*]) .
+           :in $ ?key
+           :where [?e :client-state/key ?key]]
+         (d/db conn) key)))
+
+(defn get-or-create-client-state
+  "Get existing or create new client state.
+   Returns entity map."
+  [conn client-id show-slug]
+  (if-let [state (get-client-state conn client-id show-slug)]
+    state
+    (let [key (client-state-key client-id show-slug)
+          now (long (/ (System/currentTimeMillis) 1000))]
+      (d/transact! conn [{:client-state/key key
+                          :client-state/client-id client-id
+                          :client-state/show-slug show-slug
+                          :client-state/last-seen-tx now
+                          :client-state/last-accessed-tx now}])
+      (get-client-state conn client-id show-slug))))
+
+(defn update-last-seen!
+  "Update last-seen-tx to the given timestamp.
+   Also updates last-accessed-tx to now. Uses upsert - creates if not exists."
+  [conn client-id show-slug new-last-seen]
+  (let [key (client-state-key client-id show-slug)
+        now (long (/ (System/currentTimeMillis) 1000))]
+    (if-let [existing (get-client-state conn client-id show-slug)]
+      (d/transact! conn [[:db/add [:client-state/key key] :client-state/last-seen-tx new-last-seen]
+                         [:db/add [:client-state/key key] :client-state/last-accessed-tx now]])
+      (d/transact! conn [{:client-state/key key
+                          :client-state/client-id client-id
+                          :client-state/show-slug show-slug
+                          :client-state/last-seen-tx new-last-seen
+                          :client-state/last-accessed-tx now}]))))
+
+(defn touch-accessed!
+  "Update only last-accessed-tx to now. Uses upsert."
+  [conn client-id show-slug]
+  (let [key (client-state-key client-id show-slug)
+        now (long (/ (System/currentTimeMillis) 1000))]
+    (if-let [existing (get-client-state conn client-id show-slug)]
+      (d/transact! conn [[:db/add [:client-state/key key] :client-state/last-accessed-tx now]])
+      (d/transact! conn [{:client-state/key key
+                          :client-state/client-id client-id
+                          :client-state/show-slug show-slug
+                          :client-state/last-accessed-tx now}]))))
+
+(defn delete-client-state!
+  "Delete a specific client state. Does nothing if not found."
+  [conn client-id show-slug]
+  (let [key (client-state-key client-id show-slug)]
+    (when-let [existing (get-client-state conn client-id show-slug)]
+      (d/transact! conn [[:db/retractEntity [:client-state/key key]]]))))
+
+(defn list-client-states
+  "List all client states.
+   Returns vector of entity maps."
+  [conn]
+  (d/q '[:find [(pull ?e [*]) ...]
+         :where [?e :client-state/key]]
+       (d/db conn)))
+
+(defn cleanup-old-states!
+  "Delete client states not accessed within the given number of days.
+   Returns count of deleted states."
+  [conn days]
+  (let [cutoff (- (long (/ (System/currentTimeMillis) 1000))
+                  (* days 24 60 60))
+        old-states (d/q '[:find ?e .
+                          :where
+                          [?e :client-state/key]
+                          [?e :client-state/last-accessed-tx ?tx]
+                          [(< ?tx cutoff)]]
+                        (d/db conn))
+        old-id (if (sequential? old-states)
+                 (seq old-states)
+                 (when old-states [old-states]))]
+    (when (seq old-id)
+      (d/transact! conn (mapv #(vector :db/retractEntity [:client-state/key %]) old-id)))
+    (count (or old-id []))))

--- a/src/boost_scraper/db.clj
+++ b/src/boost_scraper/db.clj
@@ -28,12 +28,19 @@
    :boostagram/time {:db/valueType :db.type/string}
    :scraper/source {:db/valueType :db.type/string}
    :boostagram/content_id {:db/valueType :db.type/string
-                           ;; TODO: enable uniqueness after we're sure this is unique enough
-                           ;; N.B. how does it work for streams? What is someone streams the same show twice?
-                           #_:db/unique #_:db.unique/identity}}
-    ;;
-    ;; :table/column {:db/valueType :db.type/...}
-  )
+                          ;; TODO: enable uniqueness after we're sure this is unique enough
+                          ;; N.B. how does it work for streams? What is someone streams the same show twice?
+                           #_:db/unique #_:db.unique/identity}
+   ;; Client state for agent tracking
+   :client-state/key {:db/valueType :db.type/string
+                      :db/unique :db.unique/identity}
+   :client-state/client-id {:db/valueType :db.type/string}
+   :client-state/show-slug {:db/valueType :db.type/string}
+   :client-state/last-seen-tx {:db/valueType :db.type/long}
+   :client-state/last-accessed-tx {:db/valueType :db.type/long}
+   ;;
+   ;; :table/column {:db/valueType :db.type/...}
+   })
 
 (defn remove-nil-vals [m]
   (->> m

--- a/src/boost_scraper/reports.clj
+++ b/src/boost_scraper/reports.clj
@@ -1,9 +1,44 @@
 (ns boost-scraper.reports
   (:require [boost-scraper.utils :as utils]
+            [boost-scraper.schemas :as schemas]
             [clojure.instant]
             [clojure.string :as str]
             [clojure.pprint :as pprint]
-            [datalevin.core :as d]))
+            [datalevin.core :as d]
+            [malli.core :as m]
+            [malli.transform :as mt]))
+
+(def ReportSchema
+  [:map
+   [:ballers {:default []} [:vector [:map {:closed false}]]]
+   [:boosts {:default []} [:vector [:map {:closed false}]]]
+   [:thanks {:default []} [:vector [:map {:closed false}]]]
+   [:boost-summary
+    [:map
+     [:boost_total_sats {:default 0} :int]
+     [:boost_total_boosts {:default 0} :int]
+     [:boost_total_boosters {:default 0} :int]]]
+   [:stream-summary
+    [:map
+     [:stream_total_sats {:default 0} :int]
+     [:stream_total_streams {:default 0} :int]
+     [:stream_total_streamers {:default 0} :int]]]
+   [:summary
+    [:map
+     [:total_sats {:default 0} :int]
+     [:total_invoices {:default 0} :int]
+     [:total_unique_boosters {:default 0} :int]
+     [:last_seen_id [:maybe :int]]]]])
+
+(def report-transformer
+  (mt/transformer
+   (mt/default-value-transformer)
+   (mt/string-transformer)))
+
+(defn normalize-report
+  "Normalize report data using ReportSchema to ensure consistent defaults."
+  [data]
+  (m/decode ReportSchema data report-transformer))
 
 (defn get-boost-summary-for-report' [conn show-regex last-seen-timestamp]
   (d/q '[:find (d/pull ?e [:db/id
@@ -215,16 +250,16 @@
     {:ballers (sort-by :total #(compare %2 %1) (map sort-boosts ballers))
      :boosts (sort-by :mindate (map sort-boosts boosts))
      :thanks (sort-by :mindate (map sort-boosts thanks))
-     :boost-summary {:boost_total_sats boost_total_sats
-                     :boost_total_boosts boost_total_boosts
-                     :boost_total_boosters boost_total_boosters}
-     :stream-summary {:stream_total_sats stream_total_sats
-                      :stream_total_streams stream_total_streams
-                      :stream_total_streamers stream_total_streamers}
-     :summary {:total_sats total_sats
-               :total_invoices total_invoices
+     :boost-summary {:boost_total_sats (or boost_total_sats 0)
+                     :boost_total_boosts (or boost_total_boosts 0)
+                     :boost_total_boosters (or boost_total_boosters 0)}
+     :stream-summary {:stream_total_sats (or stream_total_sats 0)
+                      :stream_total_streams (or stream_total_streams 0)
+                      :stream_total_streamers (or stream_total_streamers 0)}
+     :summary {:total_sats (or total_sats 0)
+               :total_invoices (or total_invoices 0)
                :last_seen_id last_seen_id
-               :total_unique_boosters total_unique_boosters}}))
+               :total_unique_boosters (or total_unique_boosters 0)}}))
 
 (defn int-comma [n] (clojure.pprint/cl-format nil "~:d" (or n 0)))
 
@@ -325,10 +360,11 @@
 (defn boost-report [conn show-regex last-seen-id]
   (->> (get-boost-summary-for-report conn show-regex last-seen-id)
        sort-report
+       normalize-report
        format-sorted-report))
 
 (defn first-booster [conn episode]
-  (d/q '[:find [(d/pull ?entity [:boostagram/sender_name  ;; what fields we want to see on the entity
+  (d/q '[:find [(d/pull ?entity [:boostagram/sender_name ;; what fields we want to see on the entity
                                  :invoice/created_at
                                  :boostagram/app_name
                                  :boostagram/value_sat_total])]

--- a/src/boost_scraper/schemas.clj
+++ b/src/boost_scraper/schemas.clj
@@ -1,0 +1,30 @@
+(ns boost-scraper.schemas
+  (:require [malli.core :as m]
+            [malli.util :as mu]))
+
+(def ClientState
+  [:map
+   [:client-state/key :string]
+   [:client-state/client-id :string]
+   [:client-state/show-slug :string]
+   [:client-state/last-seen-tx :long]
+   [:client-state/last-accessed-tx :long]])
+
+(def Boost
+  [:map
+   [:invoice/identifier :string]
+   [:invoice/source {:optional true} :string]
+   [:invoice/creation_date :long]
+   [:invoice/created_at inst?]
+   [:boostagram/sender_name {:optional true} :string]
+   [:boostagram/sender_name_normalized {:optional true} :string]
+   [:boostagram/episode {:optional true} :string]
+   [:boostagram/podcast {:optional true} :string]
+   [:boostagram/app_name {:optional true} :string]
+   [:boostagram/action :string]
+   [:boostagram/message {:optional true} :string]
+   [:boostagram/value_sat_total :long]
+   [:scraper/source {:optional true} :string]])
+
+(defn as-optional [schema]
+  (mu/optional-keys schema))

--- a/src/boost_scraper/upstream/lnd.clj
+++ b/src/boost_scraper/upstream/lnd.clj
@@ -2,7 +2,8 @@
   (:require [babashka.http-client :as http]
             [boost-scraper.upstream :as upstream]
             [boost-scraper.utils :as utils]
-            [cheshire.core :as json]))
+            [cheshire.core :as json]
+            [clojure.math :as math]))
 
 ;; macaroon -> hex
 (defn- get-path [pathstr]
@@ -16,6 +17,27 @@
       javax.xml.bind.DatatypeConverter/printHexBinary
       (#(.toLowerCase %))))
 
+(defn with-retries [f & {:keys [max-retries base-delay-ms] :or {max-retries 3 base-delay-ms 1000}}]
+  (loop [attempt 1]
+    (let [result (try
+                   {:ok (f)}
+                   (catch Exception e
+                     (if (< attempt max-retries)
+                       {:retry e}
+                       {:error e})))]
+      (if-let [e (:retry result)]
+        (let [;; Exponential backoff: base * 2^(attempt-1)
+              exp-delay (* base-delay-ms (long (math/pow 2 (dec attempt))))
+              ;; Full Jitter: random between 0 and exp-delay
+              jitter-delay (long (rand exp-delay))]
+          (println (format "Attempt %d failed, retrying in %dms (jittered from %dms)... Error: %s"
+                           attempt jitter-delay exp-delay (.getMessage e)))
+          (Thread/sleep jitter-delay)
+          (recur (inc attempt)))
+        (if-let [e (:error result)]
+          (throw e)
+          (:ok result))))))
+
 (defrecord Scraper []
   upstream/IBoostScrape
   (get-boosts [_ {:keys [token wait offset url] :as last_}]
@@ -23,12 +45,14 @@
       (println "still going!" offset url)
       (let [query-params {:reversed true}
             query-params (if offset (assoc query-params :index_offset offset) query-params)
-            data (-> (or url "https://100.115.78.27:8080/v1/invoices")
-                     (http/get {:headers {"Grpc-Metadata-macaroon" token}
-                                :client (http/client {:ssl-context {:insecure true}})
-                                :query-params query-params})
-                     :body
-                     (json/parse-string true))
+            data (with-retries
+                   (fn []
+                     (-> (or url "https://100.115.78.27:8080/v1/invoices")
+                         (http/get {:headers {"Grpc-Metadata-macaroon" token}
+                                    :client (http/client {:ssl-context {:insecure true}})
+                                    :query-params query-params})
+                         :body
+                         (json/parse-string true))))
             next_ {:next (into last_ {:macaroon token
                                       :offset (get data :first_index_offset)})
 

--- a/src/boost_scraper/web.clj
+++ b/src/boost_scraper/web.clj
@@ -3,6 +3,7 @@
             [babashka.http-client :as httpc]
             [boost-scraper.reports :as reports]
             [boost-scraper.shows :as shows]
+            [boost-scraper.client-state :as client-state]
             [cheshire.core :as json]
             [clojure.java.io :as io]
             [clojure.math :as math]
@@ -37,16 +38,30 @@
 
 (defn get-boosts [db-conn]
   (fn [request]
-    (let [{{:strs [show since json include-unknown]} :params} request
+    (let [{{:strs [show since json include-unknown client]} :params} request
           default-since (two-weeks-ago)
           json-mode (= json "true")
           include-unknown (not= include-unknown "false")
-          show-regex (shows/regex-for show include-unknown)]
+          show-regex (shows/regex-for show include-unknown)
+          client-id (when (and client (seq client) (< (count client) 256)) client)
+          show-slug (when show-regex (or (some-> show shows/resolve-show :slug) show))
+          resolved-since (cond
+                           (and since (re-matches #"^\d+$" since)) (Integer/parseInt since)
+                           (and client-id show-slug)
+                           (some-> (client-state/get-client-state db-conn client-id show-slug)
+                                   :client-state/last-seen-tx)
+                           :else default-since)]
       (cond
-        (and json-mode show since show-regex)
-        (let [show (re-pattern show-regex)
-              since (Integer/parseInt since)
-              data (reports/sort-report (reports/get-boost-summary-for-report db-conn show since))]
+        (and json-mode show show-regex resolved-since)
+        (let [show-pattern (re-pattern show-regex)
+              data (-> (reports/get-boost-summary-for-report db-conn show-pattern resolved-since)
+                       reports/sort-report
+                       reports/normalize-report)]
+          (when client-id
+            (let [new-hwm (some-> data :summary :last_seen_id)]
+              (if (and new-hwm (not= new-hwm resolved-since))
+                (client-state/update-last-seen! db-conn client-id show-slug new-hwm)
+                (client-state/touch-accessed! db-conn client-id show-slug))))
           {:status 200
            :headers {"content-type" "application/json"}
            :body (json/generate-string data)})
@@ -93,9 +108,9 @@
                    [:input#since {:name "since" :type "text" :value default-since}]
                    [:input {:type "submit" :value "Get Boosts!"}]]
                   ;; Query results
-                  (let [show (re-pattern show-regex)
-                        since (Integer/parseInt since)
-                        report (reports/boost-report db-conn show since)]
+                  (let [show-pattern (re-pattern show-regex)
+                        since resolved-since
+                        report (reports/boost-report db-conn show-pattern since)]
                     [:div#boosts {:style {:margin-top "10px" :margin-bottom "10px"}}
                      [:div {:style {"padding" "10px"}}
                       [:button#copyMarkdown {:onClick "copyMarkdown()"} "Copy Markdown"]
@@ -118,6 +133,35 @@
                         {:status 200
                          :headers {"content-type" "application/json"}
                          :body (json/generate-string {:shows (shows/show-options include-unknown)})}))}}]
+   ["/api/v1/client-states"
+    {:get {:handler (fn [_]
+                      {:status 200
+                       :headers {"content-type" "application/json"}
+                       :body (json/generate-string
+                              {:client-states
+                               (for [state (client-state/list-client-states db-conn)]
+                                 {:client (:client-state/client-id state)
+                                  :show (:client-state/show-slug state)
+                                  :last-seen-tx (:client-state/last-seen-tx state)
+                                  :last-accessed-tx (:client-state/last-accessed-tx state)})})})}
+     :delete {:handler (fn [{params :params}]
+                         (let [client (get params "client")
+                               show (get params "show")]
+                           (if (and client show)
+                             (do
+                               (client-state/delete-client-state! db-conn client show)
+                               {:status 200
+                                :headers {"content-type" "application/json"}
+                                :body (json/generate-string {:deleted true})})
+                             {:status 400
+                              :headers {"content-type" "application/json"}
+                              :body (json/generate-string {:error "client and show params required"})})))}}]
+   ["/api/v1/client-states/cleanup"
+    {:post {:handler (fn [_]
+                       (let [deleted (client-state/cleanup-old-states! db-conn 90)]
+                         {:status 200
+                          :headers {"content-type" "application/json"}
+                          :body (json/generate-string {:deleted deleted})}))}}]
    ["/boosts" {:get {:handler (get-boosts db-conn)}}]])
 
 (defn http-handler [db-conn]

--- a/test/boost_scraper/api_test.clj
+++ b/test/boost_scraper/api_test.clj
@@ -1,0 +1,59 @@
+(ns boost-scraper.api-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [babashka.http-client :as http]
+            [cheshire.core :as json]
+            [clojure.string :as str]))
+
+(def base-url (or (System/getenv "TEST_BASE_URL") "http://100.120.212.39:3223"))
+
+(defn- get-client-states []
+  (-> (http/get (str base-url "/api/v1/client-states"))
+      :body
+      (json/parse-string true)
+      :client-states))
+
+(defn- delete-client-state [client show]
+  (http/delete (str base-url "/api/v1/client-states")
+               {:query-params {:client client :show show}}))
+
+(deftest client-state-lifecycle-test
+  (let [client (str "test-client-" (System/currentTimeMillis))
+        show "lup"]
+
+    (testing "Initial state: client does not exist"
+      (let [states (get-client-states)]
+        (is (not (some #(= (:client %) client) states)))))
+
+    (testing "First request: creates client state"
+      (let [resp (http/get (str base-url "/boosts")
+                           {:query-params {:json "true" :show show :client client :since "1775604435"}})
+            data (json/parse-string (:body resp) true)
+            states (get-client-states)
+            client-state (first (filter #(= (:client %) client) states))]
+        (is (= 200 (:status resp)))
+        (is (some? client-state))
+        (is (= show (:show client-state)))
+        (is (integer? (:last-seen-tx client-state)))))
+
+    (testing "Second request (incremental): uses stored timestamp"
+      (let [states-before (get-client-states)
+            client-state-before (first (filter #(= (:client %) client) states-before))
+            last-seen-before (:last-seen-tx client-state-before)
+
+            ;; Request without 'since'
+            resp (http/get (str base-url "/boosts")
+                           {:query-params {:json "true" :show show :client client}})
+            data (json/parse-string (:body resp) true)
+
+            states-after (get-client-states)
+            client-state-after (first (filter #(= (:client %) client) states-after))]
+
+        (is (= 200 (:status resp)))
+        ;; High water mark should have moved forward or stayed same
+        (is (>= (:last-seen-tx client-state-after) last-seen-before))))
+
+    (testing "Delete client state"
+      (let [resp (delete-client-state client show)
+            states (get-client-states)]
+        (is (= 200 (:status resp)))
+        (is (not (some #(= (:client %) client) states)))))))


### PR DESCRIPTION
Add server-side client state so agents don't need to track "last seen" themselves.
- New client-state schema in Datalevin (per-client-per-show)
- GET /boosts?client=my-agent&show=lup uses stored timestamp if no explicit since
- Updates timestamps after each request
- Admin endpoints: list, delete, cleanup