### PR TITLE
Add Zaprite and R2 boost sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ age_key.txt
 decrypted_secrets
 result
 reports/
+opencode.sh

--- a/.opencode/AGENTS.md
+++ b/.opencode/AGENTS.md
@@ -31,7 +31,12 @@ There are also LND-only and Alby-only DBs at paths set via env vars `JBNODE_DBI`
 | `:boostagram/action` | string | "boost" or "stream" |
 | `:boostagram/message` | string | Text message |
 | `:boostagram/content_id` | string | SHA-256 content hash (dedup) |
-| `:scraper/source` | string | "alby" / "JB" / "nodecan" |
+| `:scraper/source` | string | "alby" / "JB" / "nodecan" / "zaprite" / "r2-member" |
+| `:boostagram/type` | keyword | `:sat` / `:fiat` / `:member-free` — set at ingest |
+| `:boostagram/r2_object_key` | string (unique) | R2 object key (member-free boosts) |
+| `:boostagram/payment_rail` | string | "lightning" / "card" / "member-free" |
+| `:boostagram/podcast_slug` | string | Short slug (e.g. "lup") |
+| `:boostagram/episode_guid` | string | Episode GUID |
 
 ### Show Registry (shows.clj)
 
@@ -50,7 +55,7 @@ Boosts match by **both** `:boostagram/podcast` AND `:boostagram/episode` using `
 
 | File | Purpose |
 |------|---------|
-| `src/boost_scraper/core.clj` | Main entry, scrape loop, sync logic |
+| `src/boost_scraper/core.clj` | Main entry, concurrent scrape loop, sync logic |
 | `src/boost_scraper/db.clj` | Schema, data coercion, boost decoding |
 | `src/boost_scraper/web.clj` | Aleph web server, HTML + JSON API |
 | `src/boost_scraper/shows.clj` | Show registry (slug → regex map) |
@@ -60,10 +65,38 @@ Boosts match by **both** `:boostagram/podcast` AND `:boostagram/episode` using `
 | `src/boost_scraper/upstream.clj` | IBoostScrape protocol |
 | `src/boost_scraper/upstream/lnd.clj` | LND REST scraper |
 | `src/boost_scraper/upstream/alby.clj` | Alby API scraper |
-| `src/boost_scraper/utils.clj` | Date formatting, virtual thread helpers |
+| `src/boost_scraper/upstream/zaprite.clj` | Zaprite API scraper (fiat + sat boosts) |
+| `src/boost_scraper/upstream/r2.clj` | R2 member-free boost scraper (cognitect.aws S3) |
+| `src/boost_scraper/utils.clj` | Date formatting, virtual thread helpers, retry logic |
 | `src/boost_scraper/analysis.clj` | **Ad-hoc analysis queries** (see skill) |
 | `src/boost_scraper/boosties.clj` | Leaderboard queries |
 | `src/boost_scraper/legacy.clj` | Old query approach (pre-refactor) |
+
+## Testing Conventions
+
+### Running tests
+```bash
+clojure -M:test              # unit tests (includes Datalevin JVM opts)
+clojure -X:test              # same, via exec-fn
+```
+
+Tests auto-discover namespaces ending in `-test`. When adding a new test namespace, name it `boost-scraper.<thing>-test` in `test/boost_scraper/<thing>_test.clj`.
+
+### Principles
+- **Unit tests need zero infrastructure**: no database, no network, no filesystem.
+- **Pure functions are tested directly**. See `db_test.clj` for `normalize-name`, `remove-nil-vals`, `sha256`, `flatten-paths`, `namespace-invoice-keys`.
+- **Protocol mocking uses `reify` on `IBoostScrape`**. See `core_test.clj` for call-counting pagination mock with `atom`.
+- **Integration tests are gated behind env vars**. `api_test.clj` only runs when `TEST_BASE_URL` is set.
+- **Edge cases are explicit**: non-divisible msats (1234 -> 1 sat), empty sequences, invalid Base64, timezone offsets.
+
+### Key test files
+| File | Tests |
+|------|-------|
+| `test/boost_scraper/db_test.clj` | Schema coercion, boost decoding, batch processing, backfill scenarios |
+| `test/boost_scraper/core_test.clj` | Scrape orchestration: `get-all-boosts-until-epoch` boundary, pagination mocking, credential gating |
+| `test/boost_scraper/upstream_test.clj` | Source scrapers: Zaprite process-order, R2 process-record, sort-report thresholds, keyword roundtrip |
+| `test/boost_scraper/reports_test.clj` | Report pipeline: sort-report, format-sorted-report, normalize-report, first-booster, podcast-app-percentages |
+| `test/boost_scraper/api_test.clj` | Integration: HTTP API lifecycle (requires `TEST_BASE_URL`) |
 
 ## Timezone
 
@@ -108,6 +141,68 @@ Produce standalone HTML with inline styles:
 - Grey pull-out boxes for key takeaways: `<p style="background: #f0f0f0; padding: .4em .8em; border-left: 3px solid #888;">`
 - Source line at bottom in grey
 - No external deps, no `<style>` blocks
+
+## Deployment
+
+### NixOS Module Options (module.nix)
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `zapriteApiKeyPath` | str | `""` | File path to Zaprite API key |
+| `r2AccessKeyIdPath` | str | `""` | File path to R2 access key ID |
+| `r2SecretAccessKeyPath` | str | `""` | File path to R2 secret access key |
+| `r2AccountId` | str | `""` | Cloudflare account ID |
+| `r2BoostBucket` | str | `""` | R2 bucket name |
+
+### Env Vars (file-path pattern for secrets)
+- `ZAPRITE_API_KEY_PATH` — path to Zaprite API key file
+- `R2_ACCESS_KEY_ID_PATH` — path to R2 access key file
+- `R2_SECRET_ACCESS_KEY_PATH` — path to R2 secret key file
+- `R2_ACCOUNT_ID` — Cloudflare account ID (direct value)
+- `R2_BOOST_BUCKET` — R2 bucket name (direct value)
+
+Secrets use `(some-> PATH not-empty slurp str/trim not-empty)` — read from files managed by sops-nix/agenix.
+
+### Checks
+```bash
+nix build .#checks.x86_64-linux.module-options  # validate module options
+nix flake check --impure                         # full flake check
+```
+
+## Price Feed & Fiat Conversion
+
+`price_feed.clj` fetches BTC/USD prices for converting fiat boost amounts to satoshis at report time.
+
+**Fallback chain** (5s timeout each):
+1. `mempool.space/api/v1/prices` — user runs their own mempool node
+2. `api.coingecko.com/api/v3/simple/price?ids=bitcoin` — CoinGecko
+3. `blockchain.info/ticker` — blockchain.info
+
+**Cache**: In-memory atom, 5-minute TTL. On source failure, returns stale cached rate with a log warning. If all sources fail and no cache exists, returns nil (fiat excluded from total, `:fiat-skipped` flag set on report).
+
+**Conversion**: `fiat_sats = fiat_cents * rate / 100`, where rate = `100,000,000 / btc_usd`. Applied in `reports.clj` `add-fiat-to-total` between `normalize-report` and `format-sorted-report`.
+
+**Display**: Summary shows `"Total Sats: 52,000 (incl. 2,000 fiat @ 1,643 sats/USD, via mempool.space)"`.
+
+## Bug Fix History (this session)
+
+| Bug | Root Cause | Fix |
+|-----|-----------|-----|
+| R2 cursor corruption | `[[cursor-str]]` double destructuring extracted first character `\m` from key string | `[cursor-str]` single destructuring |
+| Zaprite re-processes same order | `paidAtMin` API parameter is inclusive, cursor never advanced past boundary | Store cursor as `paidAt + 1ms` via `Instant/parse` + `.plusMillis` |
+| LND infinite pagination | Used `first_index_offset` (always newest, never changes) instead of `last_index_offset` | `lnd.clj:35` — one word change |
+| Alby always fetches all pages | Server-side `:since` filter existed in scraper code but was never populated from `epoch` | Pass `:since most-recent-timestamp` in `get-all-boosts-until-epoch` call |
+| Price feed returned nil on all sources | `json/parse-string` without `true` returns string-keyed maps, keyword `:USD` didn't match `"USD"` | Add `true` keywordize arg to all three API parsers |
+
+## What's Next
+
+- **Push & deploy**: 2 unpushed commits (`b5815a8`, `c9aa123`) — build and deploy to nodecan
+- **Verify price feed**: Check journalctl for `"Price feed: got BTC/USD"` after deploy
+- **Cycle interval**: Consider bumping `scrape-sleep-interval` from 60s to 300s — external API rate limits (Zaprite, R2, price feed, mempool)
+- **Alby/LND/Nodecan slow pagination**: Accept as pre-existing, or investigate `get-all-boosts-until-epoch` — they paginate through all historical invoices every cycle even when caught up
+- **Zaprite API key**: Set `zapriteApiKeyPath` in NixOS config if not done
+- **Final review on `feat/web_boost` branch**
+- **Merge PR #14** to `v2`
 
 ## Skills
 

--- a/.opencode/plans/jb-boost-integration.md
+++ b/.opencode/plans/jb-boost-integration.md
@@ -1,0 +1,109 @@
+# JB Boost Integration Plan
+
+## Overview
+Add support for two new boost sources to lnd-boost-scraper:
+1. **Zaprite paid boosts** — fiat and Lightning payments via Zaprite API
+2. **Member free boosts** — free member-perk boosts stored in Cloudflare R2
+
+All boosts flow into the existing canonical Datalevin DB (nodecan-conn) and appear in unified reports.
+
+## Workflow
+
+Every chunk follows: **READ → PLAN → ACT → VERIFY**
+
+- **READ**: `clojure_inspect_project`, `read_file`, `glob`, `grep` to understand current code
+- **PLAN**: `scratch_pad` to outline approach, confirm against overall design
+- **ACT**: `clojure_edit` (preferred for Clojure), then `cljfmt` + `clj-kondo`
+- **VERIFY**: `clojure_eval` in REPL, run test suite
+
+Commit after every clean fmt/lint pass. Rebase before merge.
+
+## Chunks
+
+### Chunk 1: Schema + data model (db.clj)
+- Add 13 new optional attributes to schema
+- Add coerce/transform fns for new source data
+- Add sync-cursor attributes for cursor tracking
+
+### Chunk 2: Shared utilities (utils.clj, upstream/lnd.clj)
+- Extract `with-retries` from lnd.clj into utils.clj
+- Add AWS SigV4 signing functions
+- Reference retry from lnd.clj via utils
+
+### Chunk 3: Zaprite scraper (upstream/zaprite.clj)
+- Fetch paginated orders from Zaprite API
+- Map to boost entity fields
+- Sync with cursor tracking
+
+### Chunk 4: R2 scraper (upstream/r2.clj)
+- S3-compatible listing and fetch from Cloudflare R2
+- AWS SigV4 signing
+- Map MemberBoostRecord to boost entity
+- Sync with cursor tracking
+
+### Chunk 5: Core integration (core.clj)
+- Wire new scrapers into scrape cycle
+- Add env var handling (all optional)
+- Run as virtual threads
+
+### Chunk 6: Report rework (reports.clj, schemas.clj)
+- 3 new Datalog queries: fiat, member-free, summaries
+- 2 new display sections: Fiat Boosts, Member Free Boosts
+- 2 new summary blocks: Fiat Summary, Member Free Summary
+- Extended Malli schemas
+- Section ordering via vector of renderer fns
+
+### Chunk 7: Tests + verification
+- Integration tests for new scrapers
+- Full test suite pass
+
+## Report structure (final)
+
+```
+## Baller Boosts          (Lightning + Zaprite BTC, ≥20k sats)
+## Boosts                 (Lightning + Zaprite BTC, 2k-20k)
+## Thanks                 (Lightning + Zaprite BTC, <2k)
+## Fiat Boosts            (USD card/ACH — dollar amounts)
+## Member Free Boosts     (free member perk)
+## Boost Summary          (existing)
+## Stream Summary         (existing)
+## Fiat Summary           (total $, count, boosters, currencies)
+## Member Free Summary    (count, boosters)
+## Summary                (total sats, total fiat, total free, total invoices, total senders)
+```
+
+## Schema additions
+
+```clojure
+:boostagram/payment_rail          string
+:boostagram/zaprite_order_id      string  unique/identity
+:boostagram/memberful_member_id   string
+:boostagram/amount_fiat_cents     long
+:boostagram/amount_fiat_currency  string
+:boostagram/received_at           instant
+:boostagram/podcast_slug          string
+:boostagram/episode_guid          string
+:boostagram/episode_key           string
+:boostagram/dedup_key             string
+:boostagram/boost_id              string
+:sync-cursor/key                  string  unique/identity
+:sync-cursor/value                string
+```
+
+## Env vars (all optional)
+
+| Var | Purpose |
+|---|---|
+| `ZAPRITE_API_KEY` | Zaprite API auth |
+| `R2_ACCOUNT_ID` | Cloudflare R2 account |
+| `R2_ACCESS_KEY_ID` | S3-compat access key |
+| `R2_SECRET_ACCESS_KEY` | S3-compat secret |
+| `R2_BOOST_BUCKET` | Bucket name |
+| `R2_BOOST_PREFIX` | Key prefix (default: `member-boosts/v1/by-date/`) |
+
+## Identity strategy
+
+| Source | Dedup attr | Value |
+|---|---|---|
+| Zaprite paid | `:boostagram/zaprite_order_id` | Zaprite order UUID |
+| Member free | `:invoice/identifier` | `"member-" + boostId` |

--- a/.opencode/plans/review-fixes.md
+++ b/.opencode/plans/review-fixes.md
@@ -1,0 +1,63 @@
+# Review-Fix Plan
+
+## Goal
+Address all findings from two sub-agent code reviews: one line-level (test correctness, edge cases, idiomatic Clojure) and one gestalt (coverage gaps, pipeline composition, sustainability).
+
+## Approach
+Each "compaction" session picks up from the todo list, works through a batch of items (fmt/lint after each), commits, and notes progress. Minimal context reload between sessions.
+
+## Test Runner Decision: `cognitect-labs/test-runner`
+
+**Chosen** over Kaocha. Rationale:
+- Auto-discovers namespaces ending in `-test` — no more manually listing them in `deps.edn`
+- Zero configuration beyond the dep itself (no `tests.edn` needed)
+- Official Cognitect project, maintained by Sean Corfield, 307 ★
+- Lightweight: just discovers and runs `clojure.test` — fits the project's modest size
+- The project already follows the `-test` naming convention
+
+Kaocha was considered: watch mode, fail-fast, profiling, pluggable reporters. Rejected as over-engineered for this project's needs. Can adopt later if CI demands it.
+
+Migration: replace the explicit `main-opts` in `:test` alias with `cognitect.test-runner` dependency + `:exec-fn`. `clojure -X:test` becomes the invocation.
+
+## Priority Order
+
+### P0 — Must fix before moving on (breaks correctness)
+
+| # | What | Files | Effort |
+|---|------|-------|--------|
+| 1 | **`quot` not `/` for msats→sats**: `(/ msats 1000)` returns a `Ratio` (e.g., `1/250`). Schema declares `:db.type/long`. All existing test values happen to be cleanly divisible. Use `(quot msats 1000)` instead. | `db.clj:230`, `db_test.clj` | 2m |
+| 2 | **Empty `creation_dates` crash**: `(apply max [])` throws `ArithmeticException` when all records in a batch lack `:creation_date`. Guard with `(when (seq creation_dates) ...)`. | `core.clj:142` | 5m |
+| 3 | **Test runner auto-discovery**: Replace explicit namespace list with `cognitect-labs/test-runner`. Add dep to `deps.edn`, switch to `:exec-fn`. | `deps.edn` | 5m |
+
+### P1 — High-value fixes and missing coverage
+
+| # | What | Files | Effort |
+|---|------|-------|--------|
+| 4 | **sort-report sort key**: Add `:invoice/created_at` to boundary test boost maps so `sort-by` is exercised. Currently all sort keys are `nil` → no-op. | `upstream_test.clj:254-318` | 5m |
+| 5 | **Misleading test name + all-nil creation_date test**: Rename and add a case that exercises the crash path. Document behavior. | `core_test.clj` | 5m |
+| 6 | **Non-divisible msats**: Add 1234 msats → 1 sats (integer division) assertion to confirm `quot` produces valid schema value. | `db_test.clj` | 2m |
+| 7 | **`process-batch` composition test**: Realistic LND-shaped input → expected output. Catches ordering bugs in the 5-step pipeline. Single highest-value missing test. | New test in `db_test.clj` | 15m |
+| 8 | **`decode-boost` test**: Known Base64 encoded boostagram → expected parsed map. Zero infrastructure. | New test in `db_test.clj` | 10m |
+| 9 | **`flatten-paths` / `namespace-invoice-keys` tests**: Recursive shape transformers — nested maps, empty maps, nil values, separator char. | New test in `db_test.clj` | 10m |
+| 10 | **Gate `api_test.clj`**: Skip when `TEST_BASE_URL` not set. Current hardcoded dev IP blocks CI. | `api_test.clj` | 5m |
+
+### P2 — Cleanup and edge cases
+
+| # | What | Files | Effort |
+|---|------|-------|--------|
+| 11 | **Remove duplicate test**: `test-remove-nil-vals-after-decode` is a copy of `test-remove-nil-vals`. | `db_test.clj` | 2m |
+| 12 | **Normalize-name nil input test**: Document that `(str/trim nil)` → `""` so the fn doesn't crash. | `db_test.clj` | 2m |
+| 13 | **Alby timezone offset**: Test `+02:00` offset in `created_at` string. | `db_test.clj` | 5m |
+
+### P3 — Sustainability
+
+| # | What | Files | Effort |
+|---|------|-------|--------|
+| 14 | **Add test conventions to AGENTS.md**: Conventions for mocking, pure fn testing, DB testing, adding new test namespaces. | `AGENTS.md` | 10m |
+| 15 | **In-memory Datalevin for `add-boosts`**: End-to-end pipeline validation with `d/get-conn` + cleanup. | New test or separate file | 20m |
+
+## Measurement
+
+Each compaction session should be able to complete at least one P0 + two P1s.
+
+After all items done, re-run both review agents to confirm exit criteria met.

--- a/API_UPDATE.md
+++ b/API_UPDATE.md
@@ -1,0 +1,37 @@
+# 📢 API Update: Client-Side State Tracking & Schema Normalization
+
+We have upgraded the Boost Scraper API to support intelligent incremental fetching and consistent JSON schemas.
+
+## 1. Native State Tracking (New!)
+Agents no longer need to track "last seen" timestamps manually. The server now handles this via the `client` parameter.
+- **Usage**: Add `&client=your-unique-id` to your `/boosts` request.
+- **Behavior**: 
+    - The first request should still include `since=UNIX_TIMESTAMP` to establish a baseline.
+    - Subsequent requests can **omit** the `since` parameter. The server will automatically return only boosts seen since your last successful request.
+    - The server tracks state per unique combination of `client` and `show`.
+
+## 2. Stable Show Slugs
+We have introduced a formal show registry with stable slugs.
+- **Discovery**: Hit `GET /api/v1/shows` to get the list of supported shows and their slugs (e.g., `lup`, `coder`, `selfhosted`).
+- **Usage**: Always use the `:slug` value in your `?show=` query parameter for guaranteed matches.
+
+## 3. Normalized JSON Output (Malli)
+The API output has been hardened using Malli schemas. 
+- **Predictable Types**: You will no longer receive `null` for collection keys when no results are found.
+- **Empty States**: If no boosts match your query, you will receive:
+    - `[]` (empty array) for `:ballers`, `:boosts`, and `:thanks`.
+    - `0` for all numeric summary fields.
+- **High Water Mark**: Check `summary.last_seen_id` to see the exact timestamp used for your client's state update.
+
+## 4. Example Incremental Pattern
+```bash
+# 1. First request (establish state)
+curl "/boosts?json=true&show=lup&client=agent-001&since=1713139200"
+
+# 2. Subsequent requests (server remembers where you left off)
+curl "/boosts?json=true&show=lup&client=agent-001"
+```
+
+## 5. Management Endpoints
+- `GET /api/v1/client-states`: View current high-water marks for all registered clients.
+- `DELETE /api/v1/client-states?client=...&show=...`: Reset state for a specific client.

--- a/deps-lock.json
+++ b/deps-lock.json
@@ -1,6 +1,15 @@
 {
   "lock-version": 4,
-  "git-deps": [],
+  "git-deps": [
+    {
+      "lib": "io.github.cognitect-labs/test-runner",
+      "url": "https://github.com/cognitect-labs/test-runner.git",
+      "rev": "dfb30dd6605cb6c0efc275e1df1736f6e90d4d73",
+      "tag": "v0.5.1",
+      "git-dir": "https/github.com/cognitect-labs/test-runner",
+      "hash": "sha256-PUNd+dHJNPTKno59YI27wpehyULYPvSyCQDjVIadKJ4="
+    }
+  ],
   "mvn-deps": [
     {
       "mvn-path": "aero/aero/1.1.6/aero-1.1.6.jar",
@@ -88,11 +97,6 @@
       "hash": "sha256-JezOPysastKFP6SSVze/8ZvwYnbr/uu5PhHvdTc7ea8="
     },
     {
-      "mvn-path": "cheshire/cheshire/5.10.0/cheshire-5.10.0.pom",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-l3PHeIYLYeUXTVeUfJQIGwaJY6aaL7ABmhGpGuN9l8w="
-    },
-    {
       "mvn-path": "cheshire/cheshire/5.13.0/cheshire-5.13.0.jar",
       "mvn-repo": "https://repo.clojars.org/",
       "hash": "sha256-wAlhAWDKih2Kba1TB9BtFx0xjNQm7CSZkMF/6OC4muw="
@@ -163,6 +167,16 @@
       "hash": "sha256-o2UIvjWMxx12F0UZyCBX9OLm5LIOUnqwcHskGGQBsoE="
     },
     {
+      "mvn-path": "com/cognitect/aws/endpoints/871.2.46.0/endpoints-871.2.46.0.jar",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-h2yuGPGkI/XXuG3lLoM9mfpY4Exrw19cD7rodve7U5s="
+    },
+    {
+      "mvn-path": "com/cognitect/aws/endpoints/871.2.46.0/endpoints-871.2.46.0.pom",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-K5yM+0e9y0UB/Sokib2oR86LKqNV53GZiwk9fvSn86A="
+    },
+    {
       "mvn-path": "com/cognitect/aws/s3/871.2.29.35/s3-871.2.29.35.jar",
       "mvn-repo": "https://repo1.maven.org/maven2/",
       "hash": "sha256-AX3ZHiHsggPnTkkOUDyrO3lq5tZe7u+NQyrZUyHlmxs="
@@ -173,9 +187,14 @@
       "hash": "sha256-o6yItldqbUgs+Rw2GEMqJC0ArNtzkLxhDrzt+OdCiNQ="
     },
     {
-      "mvn-path": "com/cognitect/transit-clj/1.0.324/transit-clj-1.0.324.pom",
+      "mvn-path": "com/cognitect/aws/s3/871.2.43.0/s3-871.2.43.0.jar",
       "mvn-repo": "https://repo1.maven.org/maven2/",
-      "hash": "sha256-2KiGaliPynFU05XvzSsW3xy7WHRrUofA/tZ+XcIVPiM="
+      "hash": "sha256-YTNB32oKKVGA79oZ/xDquJNLhgmreqgmjEoC9PMwYC0="
+    },
+    {
+      "mvn-path": "com/cognitect/aws/s3/871.2.43.0/s3-871.2.43.0.pom",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-APBxjbsG2SvUfL+a8IqCms6Vo0RsR878O3PcMVFny1o="
     },
     {
       "mvn-path": "com/cognitect/transit-clj/1.0.333/transit-clj-1.0.333.jar",
@@ -388,14 +407,14 @@
       "hash": "sha256-6oYs472WzLjKNrjp57rvLaP7v73CVrrqqMioc5EQdOc="
     },
     {
-      "mvn-path": "com/github/liquidz/antq/2.11.1264/antq-2.11.1264.jar",
+      "mvn-path": "com/github/liquidz/antq/2.11.1276/antq-2.11.1276.jar",
       "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-RAU2szmbxia4Sd8gmKkVnrlviDtkZBT3pdRwOptUyhY="
+      "hash": "sha256-vc40JiJw/KtR7teImULZEqh/VyRlkP1yLpfuf7tTFXg="
     },
     {
-      "mvn-path": "com/github/liquidz/antq/2.11.1264/antq-2.11.1264.pom",
+      "mvn-path": "com/github/liquidz/antq/2.11.1276/antq-2.11.1276.pom",
       "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-Lgmp6Nuv2fqDUFm7AQuzrGxzpGmyDOW46p0EB6P8xWU="
+      "hash": "sha256-a5O2L1GPEv1HE49zWV5xwWutCV+SSx9z+aVJdBihLHA="
     },
     {
       "mvn-path": "com/github/liquidz/rewrite-indented/0.2.44/rewrite-indented-0.2.44.jar",
@@ -1113,21 +1132,6 @@
       "hash": "sha256-sAogZY/OzCvRNBAx85T1LWjFP7SAxEVBNMyqwgTqWTE="
     },
     {
-      "mvn-path": "metosin/jsonista/0.3.1/jsonista-0.3.1.pom",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-PRsAehAljlwx/NPiElrACR5K9473ngL2LUZepECSfGY="
-    },
-    {
-      "mvn-path": "metosin/jsonista/0.3.10/jsonista-0.3.10.pom",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-WLoZaVpBwlvWneXxJTN4Yibs0q1xM0y99pGkBj6GfxU="
-    },
-    {
-      "mvn-path": "metosin/jsonista/0.3.11/jsonista-0.3.11.pom",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-VHOl7m+3/IfN0dzc86Ph1Gkg4rLQNhsK3EYAPyBVSsw="
-    },
-    {
       "mvn-path": "metosin/jsonista/0.3.13/jsonista-0.3.13.jar",
       "mvn-repo": "https://repo.clojars.org/",
       "hash": "sha256-t5t987GErfKdAfRcWlBaE4g+icAHktd2lGwVwvdUIfs="
@@ -1151,11 +1155,6 @@
       "mvn-path": "metosin/malli/0.17.0/malli-0.17.0.pom",
       "mvn-repo": "https://repo.clojars.org/",
       "hash": "sha256-GgrWQQcfg0MI4fU0hon1Fjsbe2thxO/gTDN+/pYkY50="
-    },
-    {
-      "mvn-path": "metosin/muuntaja/0.6.10/muuntaja-0.6.10.pom",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-Fp5rsCbCqvx2ZiAHrqRo7sCwea0LRmW8kUIzGMdpDNs="
     },
     {
       "mvn-path": "metosin/muuntaja/0.6.11/muuntaja-0.6.11.jar",
@@ -2083,6 +2082,16 @@
       "hash": "sha256-tiNt98lr1iLzSkhWsGOuCna1RrWhGzZ93eVLvjI4dSo="
     },
     {
+      "mvn-path": "org/clojure/java.classpath/1.0.0/java.classpath-1.0.0.jar",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-wU4OEDBKXlz9LMdC+976wfUpPuxgcML/6JA/tcf+fW8="
+    },
+    {
+      "mvn-path": "org/clojure/java.classpath/1.0.0/java.classpath-1.0.0.pom",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-C+AThRRX/CTENM5FU0ZD8iblwQgASGJT/Tc/LglUXig="
+    },
+    {
       "mvn-path": "org/clojure/pom.contrib/0.2.2/pom.contrib-0.2.2.pom",
       "mvn-repo": "https://repo1.maven.org/maven2/",
       "hash": "sha256-4OoifEnFw+MHVM0m/MV75+Telz/kOqXMZmdAHsXBAyM="
@@ -2091,6 +2100,11 @@
       "mvn-path": "org/clojure/pom.contrib/0.3.0/pom.contrib-0.3.0.pom",
       "mvn-repo": "https://repo.maven.apache.org/maven2/",
       "hash": "sha256-fxgrOypUPgV0YL+T/8XpzvasUn3xoTdqfZki6+ee8Rk="
+    },
+    {
+      "mvn-path": "org/clojure/pom.contrib/1.0.0/pom.contrib-1.0.0.pom",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-EBH6rlyeSWhY5MZQujNxOr1Gml1S4Arrf1sBoryvR+k="
     },
     {
       "mvn-path": "org/clojure/pom.contrib/1.1.0/pom.contrib-1.1.0.pom",
@@ -2163,6 +2177,11 @@
       "hash": "sha256-iCMhqlKL6Q+9ikOlem76axkg+i6g7cf++kHzzTf3IQU="
     },
     {
+      "mvn-path": "org/clojure/tools.cli/1.0.206/tools.cli-1.0.206.pom",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-/QDNC4q1yffBaViwVlAtuvcqR6TLiG6AArWw27s49J4="
+    },
+    {
       "mvn-path": "org/clojure/tools.cli/1.1.230/tools.cli-1.1.230.jar",
       "mvn-repo": "https://repo1.maven.org/maven2/",
       "hash": "sha256-kWYwtTmkP/RotN0BbGKFfitMtdpmhvEpdYfN1DyhAs0="
@@ -2173,14 +2192,14 @@
       "hash": "sha256-v7Yh5LAaW4vOEWpgcIQNzdWUnomceEaNgRtuiqqf0cc="
     },
     {
-      "mvn-path": "org/clojure/tools.deps/0.21.1467/tools.deps-0.21.1467.jar",
+      "mvn-path": "org/clojure/tools.deps/0.23.1512/tools.deps-0.23.1512.jar",
       "mvn-repo": "https://repo1.maven.org/maven2/",
-      "hash": "sha256-MyA3Djm0IHbr4eQp8EYPWa2iObyDVeC+XNOFTGvfysw="
+      "hash": "sha256-kKy7g0yrQFER/E3ErQnDFu5Ecg5pSaGvwPsuxxJp6gg="
     },
     {
-      "mvn-path": "org/clojure/tools.deps/0.21.1467/tools.deps-0.21.1467.pom",
+      "mvn-path": "org/clojure/tools.deps/0.23.1512/tools.deps-0.23.1512.pom",
       "mvn-repo": "https://repo1.maven.org/maven2/",
-      "hash": "sha256-3vUnx4GB2XevLLkQt2k06nyVafl3cTxlrqidcZm9ypM="
+      "hash": "sha256-WwHb9tBctCoeO5d4NGJ2SvgiKmiHFGxmVkPZVAX6c5w="
     },
     {
       "mvn-path": "org/clojure/tools.gitlibs/2.6.206/tools.gitlibs-2.6.206.jar",
@@ -2203,9 +2222,19 @@
       "hash": "sha256-E15H98p5wKoYG2kJPML50aYyKt1qgli2aXxQCNIwv00="
     },
     {
-      "mvn-path": "org/clojure/tools.reader/1.4.2/tools.reader-1.4.2.jar",
+      "mvn-path": "org/clojure/tools.namespace/1.3.0/tools.namespace-1.3.0.jar",
       "mvn-repo": "https://repo1.maven.org/maven2/",
-      "hash": "sha256-XcBwJiXj2CmkqVc1XHy/lmzURwCGSU62Fp5sqGVD6IE="
+      "hash": "sha256-EnUzqx4eenAMgjitfVjUtCxBjW2PNMMEcRUDvIguOnA="
+    },
+    {
+      "mvn-path": "org/clojure/tools.namespace/1.3.0/tools.namespace-1.3.0.pom",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-e5Sl5sIS2bDFQhGM6SYm5ujcPu1SZ07kYuON1lWTuZQ="
+    },
+    {
+      "mvn-path": "org/clojure/tools.reader/1.3.6/tools.reader-1.3.6.pom",
+      "mvn-repo": "https://repo1.maven.org/maven2/",
+      "hash": "sha256-rvXugot8sUocWPRbn4oQ/zQMV2mSXqDvXDXR5J2SC+o="
     },
     {
       "mvn-path": "org/clojure/tools.reader/1.4.2/tools.reader-1.4.2.pom",

--- a/deps.edn
+++ b/deps.edn
@@ -1,31 +1,30 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
-         ;; database
         datalevin/datalevin {:mvn/version "0.9.13"}
-         ;; HTTP
         cheshire/cheshire {:mvn/version "5.13.0"}
-        org.babashka/http-client {:mvn/version "0.4.22"}
+         org.babashka/http-client {:mvn/version "0.4.22"}
+         com.cognitect.aws/s3 {:mvn/version "871.2.43.0"}
+         com.cognitect.aws/api {:mvn/version "0.8.723"}
+         com.cognitect.aws/endpoints {:mvn/version "871.2.46.0"}
         aleph/aleph {:mvn/version "0.8.2"}
         metosin/reitit {:mvn/version "0.7.2"}
         metosin/muuntaja {:mvn/version "0.6.11"}
-         ;; markdown and hiccup
         com.kiranshila/cybermonday {:mvn/version "0.6.215"}
         dev.onionpancakes/chassis {:mvn/version "1.0.365"}
-         ;; validation
         metosin/malli {:mvn/version "0.17.0"}
-         ;; config
         aero/aero {:mvn/version "1.1.6"}
-         ;; cli interface
         org.babashka/cli {:mvn/version "0.8.60"}}
  :aliases
- {:jvm-base {:jvm-opts [;; required by datalevin
-                        "--add-opens=java.base/java.nio=ALL-UNNAMED"
+ {:jvm-base {:jvm-opts ["--add-opens=java.base/java.nio=ALL-UNNAMED"
                         "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
-                        ;; lnd uses cert with "localhost"
                         "-Djdk.internal.httpclient.disableHostnameVerification"]}
   :neil {:project {:name com.noblepayne/lnd-boost-scraper}}
-  :outdated {;; Note that it is `:deps`, not `:extra-deps`
-             :deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
+  :outdated {:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
              :main-opts ["-m" "antq.core"]}
   :test {:extra-paths ["test"]
-         :main-opts ["-e" "(require 'boost-scraper.api-test) (clojure.test/run-tests 'boost-scraper.api-test)"]}}}
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+         :main-opts ["-m" "cognitect.test-runner"]
+         :exec-fn cognitect.test-runner.api/test
+         :jvm-opts ["--add-opens=java.base/java.nio=ALL-UNNAMED"
+                    "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"]}}}

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,0 +1,90 @@
+# lnd-boost-scraper contract notes
+
+The durable writer-side contract lives at `web-boost/docs/shared-interface.md`
+in the web-boost-worker repo. Verified against the worker source at
+`functions/api/member-boost.ts` and `functions/_lib/member-boosts.ts`.
+
+This doc is the scraper's consumer-side notes: what we read, what we store,
+where we deliberately deviate from the spec.
+
+## What we read
+
+### R2 ($1 of upstream contract)
+
+- Key format: `member-boosts/v1/r/{base36_ts}-{uuid}.json` (base36-encoded
+  `createdAt` ms timestamp, then `-`, then `boostId` as UUID v4)
+  - The spec says `{ulid}.json` but the worker uses a UUID — lex order
+    preserved either way
+- We do NOT list `d/` (sentinels — they exist for atomic dedup at write time,
+  not for the scraper to read)
+- 10-field record body per $1.2 of upstream contract; the field name for the
+  sender is `username` (confirmed at `functions/api/member-boost.ts:64`)
+
+### Zaprite ($2 of upstream contract)
+
+- Statuses: `PAID`, `COMPLETE`, `OVERPAID`
+- Filter on `metadata.app == "web-boost"`
+- 5-field metadata ($2.1 of upstream contract)
+
+### Cursors ($4 of upstream contract)
+
+- R2: `sync-cursor/key` = `"r2-member"`, value = lex-last R2 key
+- Zaprite: `sync-cursor/key` = `"zaprite"`, value = `paidAt` ISO timestamp
+
+## How we store it
+
+Field-to-attribute mapping is in:
+- `src/boost_scraper/upstream/r2.clj` :: `process-record`
+- `src/boost_scraper/upstream/zaprite.clj` :: `process-order`
+
+Read those for the current truth. Identity:
+- R2: `:boostagram/r2_object_key` = full R2 key (`:db/unique :db.unique/identity`)
+- Zaprite: `:boostagram/zaprite_order_id` = Zaprite order UUID (`:db/unique :db.unique/identity`)
+
+Time semantics:
+- `:invoice/created_at` (Date), `:invoice/creation_date` (long epoch),
+  `:boostagram/received_at` (Date) all derived from the upstream timestamp.
+  Three fields, same source. Kept separate so future work can distinguish
+  "upstream view" (`received_at`) from "our view" (`created_at`) if needed.
+
+## Fields read but always absent (future-proofing)
+
+- `:boostagram/amount_fiat_cents` and `:boostagram/amount_fiat_currency` are
+  read from the R2 record body. The current worker (`_lib/member-boosts.ts:21`)
+  explicitly forbids payment fields (`amount`, `currency`, `value`, `sats`,
+  `usd`) in member boost requests, so these will always be nil. They are
+  retained for forward compatibility if fiat member boosts are added later.
+
+## Fields dropped from original plan
+
+- `:boostagram/episode_key`: Not stored. Reports query by podcast/episode via
+  `:boostagram/podcast` and `:boostagram/episode` which are always set by all
+  three ingest paths. A separate lookup key adds no value.
+- `:boostagram/dedup_key`: Not stored. Dedup is handled at the write level by
+  `:db/unique` on `:boostagram/r2_object_key` and `:boostagram/zaprite_order_id`.
+  An application-level dedup key would duplicate the DB's own identity mechanism.
+
+## Deviations from upstream contract
+
+- We store the raw `memberId` (no HMAC). Memberful member IDs are not PII
+  on their own (opaque integers, not credentials). Storing raw lets us join
+  boost -> member profile without an unmapping table.
+- We do not store `episodePubDate`. It is not displayed in any current report.
+  If a future report needs it, add the field then.
+- We do not use a versioned cursor key (`r2-member-v1` per the spec). We use
+  `r2-member` because no old-format cursor exists in the wild; the scraper
+  has never run against the R2 bucket. If a stale `r2-member` cursor ever
+  exists with the wrong value format, the migration is a one-shot `d/retract`
+  at sync start.
+
+## Open items to revisit
+
+- `:boostagram/time` vs `:boostagram/ts`: `time` is a wall-clock string
+  (LND-ism, "HH:MM:SS"), `ts` is epoch long. New sources (R2, Zaprite)
+  set `ts` but not `time`. Should we drop `:boostagram/time` from the
+  schema? Currently only LND display formatting uses it, and reports format
+  dates from `:invoice/created_at`. Decide in a follow-up PR.
+- Zaprite cursor timestamp precision: `paidAt` ISO timestamp in Zaprite
+  responses may or may not include fractional seconds. If whole-seconds,
+  each sync re-fetches orders within the same second. Cheap in practice,
+  not free. Verify with test creds.

--- a/flake.nix
+++ b/flake.nix
@@ -119,6 +119,31 @@
         };
       })
       nixpkgs.legacyPackages;
+    checks =
+      builtins.mapAttrs (system: pkgs: let
+        eval = pkgs.lib.evalModules {
+          modules = [
+            ./module.nix
+            { services.lnd-boost-scraper.enable = false; }
+            { _module.check = false; }
+          ];
+          specialArgs = { inherit pkgs; };
+        };
+        opts = eval.options.services.lnd-boost-scraper;
+      in {
+        module-options = assert opts.zapriteApiKeyPath.type.name == "str";
+          assert opts.r2AccessKeyIdPath.type.name == "str";
+          assert opts.r2SecretAccessKeyPath.type.name == "str";
+          assert opts.r2AccountId.type.name == "str";
+          assert opts.r2BoostBucket.type.name == "str";
+          assert opts.zapriteApiKeyPath.default == "";
+          assert opts.r2AccessKeyIdPath.default == "";
+          assert opts.r2SecretAccessKeyPath.default == "";
+          assert opts.r2AccountId.default == "";
+          assert opts.r2BoostBucket.default == "";
+          pkgs.runCommand "check-module-options" {} "touch $out";
+      })
+      nixpkgs.legacyPackages;
     nixosModules = {
       default = {
         options,

--- a/module.nix
+++ b/module.nix
@@ -33,6 +33,31 @@ with lib; let
     nodecanMacaroonPath = mkOption {
       type = types.str;
     };
+    zapriteApiKeyPath = mkOption {
+      type = types.str;
+      default = "";
+      description = "Path to the Zaprite API key file. Empty to disable.";
+    };
+    r2AccessKeyIdPath = mkOption {
+      type = types.str;
+      default = "";
+      description = "Path to the R2 access key ID file. Empty to disable.";
+    };
+    r2SecretAccessKeyPath = mkOption {
+      type = types.str;
+      default = "";
+      description = "Path to the R2 secret access key file. Empty to disable.";
+    };
+    r2AccountId = mkOption {
+      type = types.str;
+      default = "";
+      description = "R2 Cloudflare account ID (subdomain of r2.cloudflarestorage.com).";
+    };
+    r2BoostBucket = mkOption {
+      type = types.str;
+      default = "";
+      description = "R2 bucket name for member boost records.";
+    };
     pkg = mkOption {
       type = types.package;
       defaultText = "config.lnd-boost-scraper.pkg";
@@ -83,6 +108,11 @@ in {
         JBNODE_MACAROON_PATH = cfg.jbnodeMacaroonPath;
         NODECAN_MACAROON_PATH = cfg.nodecanMacaroonPath;
         SCRAPER_UIPORT = builtins.toString cfg.uiPort;
+        ZAPRITE_API_KEY_PATH = cfg.zapriteApiKeyPath;
+        R2_ACCESS_KEY_ID_PATH = cfg.r2AccessKeyIdPath;
+        R2_SECRET_ACCESS_KEY_PATH = cfg.r2SecretAccessKeyPath;
+        R2_ACCOUNT_ID = cfg.r2AccountId;
+        R2_BOOST_BUCKET = cfg.r2BoostBucket;
       };
     };
   };

--- a/src/boost_scraper/client_state.clj
+++ b/src/boost_scraper/client_state.clj
@@ -39,7 +39,7 @@
   [conn client-id show-slug new-last-seen]
   (let [key (client-state-key client-id show-slug)
         now (long (/ (System/currentTimeMillis) 1000))]
-    (if-let [existing (get-client-state conn client-id show-slug)]
+    (if (get-client-state conn client-id show-slug)
       (d/transact! conn [[:db/add [:client-state/key key] :client-state/last-seen-tx new-last-seen]
                          [:db/add [:client-state/key key] :client-state/last-accessed-tx now]])
       (d/transact! conn [{:client-state/key key
@@ -53,7 +53,7 @@
   [conn client-id show-slug]
   (let [key (client-state-key client-id show-slug)
         now (long (/ (System/currentTimeMillis) 1000))]
-    (if-let [existing (get-client-state conn client-id show-slug)]
+    (if (get-client-state conn client-id show-slug)
       (d/transact! conn [[:db/add [:client-state/key key] :client-state/last-accessed-tx now]])
       (d/transact! conn [{:client-state/key key
                           :client-state/client-id client-id
@@ -64,7 +64,7 @@
   "Delete a specific client state. Does nothing if not found."
   [conn client-id show-slug]
   (let [key (client-state-key client-id show-slug)]
-    (when-let [existing (get-client-state conn client-id show-slug)]
+    (when (get-client-state conn client-id show-slug)
       (d/transact! conn [[:db/retractEntity [:client-state/key key]]]))))
 
 (defn list-client-states
@@ -79,8 +79,8 @@
   "Delete client states not accessed within the given number of days.
    Returns count of deleted states."
   [conn days]
-  (let [cutoff (- (long (/ (System/currentTimeMillis) 1000))
-                  (* days 24 60 60))
+  (let [#_:clj-kondo/ignore cutoff (- (long (/ (System/currentTimeMillis) 1000))
+                                      (* days 24 60 60))
         old-states (d/q '[:find ?e .
                           :where
                           [?e :client-state/key]

--- a/src/boost_scraper/core.clj
+++ b/src/boost_scraper/core.clj
@@ -7,6 +7,8 @@
             [boost-scraper.upstream :as upstream]
             [boost-scraper.upstream.alby :as alby]
             [boost-scraper.upstream.lnd :as lnd]
+            [boost-scraper.upstream.r2 :as r2]
+            [boost-scraper.upstream.zaprite :as zaprite]
             [boost-scraper.utils :as utils]
             [boost-scraper.web :as web]
             [clojure.string :as str]
@@ -75,7 +77,7 @@
                :where
                [?e :boostagram/content_id ?cid]]
              (d/db src-conn) src-boost-cids)
-        entities (map #(dissoc % :db/id) entities)]
+        entities (map #(db/remove-empty-vals (dissoc % :db/id)) entities)]
     (d/transact! dest-conn entities)))
 
 (def max-allowed-time-for-boost
@@ -136,10 +138,11 @@
           (let [filtered-batch (filter :creation_date boost-batch)
                 creation_dates (map (comp #(if (int? %) % (Integer/parseInt %))
                                           :creation_date)
-                                    filtered-batch)
-                first_creation_date (apply max creation_dates)]
-            ;; TODO: tests; <= or <?
-            (<= epoch first_creation_date))))))
+                                    filtered-batch)]
+            (if (seq creation_dates)
+              (<= epoch (apply max creation_dates))
+              (do (println "WARNING: get-all-boosts-until-epoch batch has no records with creation_date — iteration will stop. Batch count:" (count boost-batch))
+                  nil)))))))
 
 (def AUTOSCRAPE_START (->epoch #inst "2023-12-31T23:59Z"))
 #_(def AUTOSCRAPE_START (->epoch #inst "2024-09-01T00:00Z"))
@@ -155,7 +158,7 @@
                (d/db conn))
           [AUTOSCRAPE_START])]
     (println "alby most-recent-timestamp: " most-recent-timestamp)
-    (->> (get-all-boosts-until-epoch (alby/->Scraper) token most-recent-timestamp :wait wait)
+    (->> (get-all-boosts-until-epoch (alby/->Scraper) token most-recent-timestamp :wait wait :since most-recent-timestamp)
          (db/add-boosts conn "alby"))))
 
 (defn scrape-lnd-boosts-until-epoch [conn macaroon epoch wait]
@@ -209,7 +212,14 @@
 (defn -main [& _]
   ;; TODO: proper startup validation
   (let [env (System/getenv)
-        {:strs [JBNODE_MACAROON_PATH NODECAN_MACAROON_PATH ALBY_TOKEN_PATH ALBY_DBI JBNODE_DBI NODECAN_DBI]} env]
+        {:strs [JBNODE_MACAROON_PATH NODECAN_MACAROON_PATH ALBY_TOKEN_PATH ALBY_DBI JBNODE_DBI NODECAN_DBI
+                ZAPRITE_API_KEY_PATH R2_ACCESS_KEY_ID_PATH R2_SECRET_ACCESS_KEY_PATH
+                R2_ACCOUNT_ID R2_BOOST_BUCKET]} env
+        zaprite-api-key (some-> ZAPRITE_API_KEY_PATH not-empty slurp str/trim not-empty)
+        r2-access-key (some-> R2_ACCESS_KEY_ID_PATH not-empty slurp str/trim not-empty)
+        r2-secret-key (some-> R2_SECRET_ACCESS_KEY_PATH not-empty slurp str/trim not-empty)
+        r2-account-id (not-empty R2_ACCOUNT_ID)
+        r2-bucket (not-empty R2_BOOST_BUCKET)]
     (when (not (and JBNODE_MACAROON_PATH NODECAN_MACAROON_PATH ALBY_TOKEN_PATH ALBY_DBI JBNODE_DBI NODECAN_DBI))
       (println "Missing required credentials!" {:jbnode JBNODE_MACAROON_PATH :nodecan NODECAN_MACAROON_PATH :alby ALBY_TOKEN_PATH})
       (System/exit 1))
@@ -217,7 +227,7 @@
           alby-conn (d/get-conn ALBY_DBI db/schema)
           nodecan-conn (d/get-conn NODECAN_DBI db/schema)
           lnd-macaroon (lnd/read-macaroon JBNODE_MACAROON_PATH)
-          nodecan-macaroon (lnd/read-macaroon  NODECAN_MACAROON_PATH)
+          nodecan-macaroon (lnd/read-macaroon NODECAN_MACAROON_PATH)
           alby-token (alby/load-key ALBY_TOKEN_PATH)
           runtime (Runtime/getRuntime)
           webserver (web/serve nodecan-conn)
@@ -228,24 +238,55 @@
                                    (d/close lnd-conn)
                                    (d/close nodecan-conn)
                                    (d/close alby-conn)))
-          _ (.addShutdownHook runtime shutdown-hook)]
+           _ (.addShutdownHook runtime shutdown-hook)]
+      ;; Backfill boost type for legacy entities
+      (db/backfill-boost-type! nodecan-conn)
+      (if zaprite-api-key
+        (println "Zaprite scraping enabled")
+        (println "Zaprite scraping disabled (set ZAPRITE_API_KEY_PATH)"))
+      (if (and r2-account-id r2-access-key r2-secret-key r2-bucket)
+        (println "R2 member-boost scraping enabled")
+        (println "R2 member-boost scraping disabled (set R2_ACCOUNT_ID, R2_ACCESS_KEY_ID_PATH, R2_SECRET_ACCESS_KEY_PATH, R2_BOOST_BUCKET)"))
       (while true
         (try
           (println "Starting Scrape Cycle...")
-          ;; Run in parallel and wait for all to complete.
-          (println "Scraping in parallel...")
-          (run! deref [(utils/apply-virtual autoscrape-alby alby-conn alby-token 3000)
-                       (utils/apply-virtual autoscrape-lnd lnd-conn lnd-macaroon 500)
-                       (utils/apply-virtual autoscrape-nodecan nodecan-conn nodecan-macaroon 500)])
-          (println "Scrape phase complete.")
-          (println)
-          (println "Syncing missing boosts")
-          (println "Syncing JB")
-          (sync-mising-boosts! nodecan-conn lnd-conn (- AUTOSCRAPE_START 3600) #_(two-days-ago))
-          (println "Syncing alby")
-          (sync-mising-boosts! nodecan-conn alby-conn (- AUTOSCRAPE_START 3600) #_(two-days-ago))
-          (println "Finished syncing missing boosts")
-          (println)
+          ;; Launch all scraper groups concurrently.
+          (let [alby-fut    (utils/apply-virtual autoscrape-alby alby-conn alby-token 3000)
+                lnd-fut     (utils/apply-virtual autoscrape-lnd lnd-conn lnd-macaroon 500)
+                nodecan-fut (utils/apply-virtual autoscrape-nodecan nodecan-conn nodecan-macaroon 500)
+                zaprite-fut (when zaprite-api-key
+                              (utils/apply-virtual
+                               (fn [] (zaprite/sync-zaprite-boosts! nodecan-conn zaprite-api-key))))
+                r2-fut      (when (and r2-account-id r2-access-key r2-secret-key r2-bucket)
+                              (utils/apply-virtual
+                               (fn [] (r2/sync-r2-boosts! nodecan-conn
+                                                          {:account-id r2-account-id
+                                                           :access-key r2-access-key
+                                                           :secret-key r2-secret-key
+                                                           :bucket r2-bucket}))))]
+            ;; Wait for all scrapers, logging individual errors.
+            (doseq [[label timeout-ms f] [["Alby"    600000 alby-fut]
+                                          ["JB"      600000 lnd-fut]
+                                          ["Nodecan" 600000 nodecan-fut]
+                                          ["Zaprite" 300000 zaprite-fut]
+                                          ["R2"      300000 r2-fut]]]
+              (when f
+                (try
+                  (let [result (deref f timeout-ms nil)]
+                    (when (nil? result)
+                      (println label "scrape timed out (" (/ timeout-ms 1000) "s)")))
+                 (catch Exception e
+                   (println label "scrape error:" (.getMessage e)))))))
+          ;; Sync missing boosts (after LND/Alby scrapers complete)
+          (try
+            (println "Syncing missing boosts...")
+            (println "Syncing JB")
+            (sync-mising-boosts! nodecan-conn lnd-conn (- AUTOSCRAPE_START 3600) #_(two-days-ago))
+            (println "Syncing alby")
+            (sync-mising-boosts! nodecan-conn alby-conn (- AUTOSCRAPE_START 3600) #_(two-days-ago))
+            (println "Finished syncing missing boosts")
+            (catch Exception e
+              (println "Sync error:" (.getMessage e))))
           (println "Scrape Cycle finished, sleeping.")
           (Thread/sleep scrape-sleep-interval)
           (catch Exception e (println "ERROR WHILE SCRAPING! " (bean e))))))))
@@ -315,7 +356,7 @@
        (sort-by :invoice/creation_date)
        (spit "/tmp/after_sync"))
 
-  (->> #_(->epoch #inst "2024-08-05T06:00")   1724611594
+  (->> #_(->epoch #inst "2024-08-05T06:00") 1724611594
        (boost-scraper.reports/boost-report lnd-conn #"(?i).*unplugged.*")
        #_(into [] cat)
        #_(sort-by :invoice/creation_date)

--- a/src/boost_scraper/db.clj
+++ b/src/boost_scraper/db.clj
@@ -39,10 +39,27 @@
    :client-state/last-seen-tx {:db/valueType :db.type/long}
    :client-state/last-accessed-tx {:db/valueType :db.type/long}
    ;;
-   ;; :table/column {:db/valueType :db.type/...}
-   })
+   ;; New boost source fields
+   :boostagram/payment_rail {:db/valueType :db.type/string}
+   :boostagram/zaprite_order_id {:db/valueType :db.type/string
+                                 :db/unique :db.unique/identity}
+   :boostagram/r2_object_key {:db/valueType :db.type/string
+                              :db/unique :db.unique/identity}
+   :boostagram/memberful_member_id {:db/valueType :db.type/string}
+   :boostagram/amount_fiat_cents {:db/valueType :db.type/long}
+   :boostagram/amount_fiat_currency {:db/valueType :db.type/string}
+   :boostagram/received_at {:db/valueType :db.type/instant}
+   :boostagram/podcast_slug {:db/valueType :db.type/string}
+   :boostagram/episode_guid {:db/valueType :db.type/string}
 
-(defn remove-nil-vals [m]
+   :boostagram/type {:db/valueType :db.type/keyword}
+   :boostagram/boost_id {:db/valueType :db.type/string}
+   ;; Sync cursor tracking
+   :sync-cursor/key {:db/valueType :db.type/string
+                     :db/unique :db.unique/identity}
+   :sync-cursor/value {:db/valueType :db.type/string}})
+
+(defn remove-empty-vals [m]
   (->> m
        (remove
         (fn [[_ v]]
@@ -94,7 +111,7 @@
           (.decode rawboost)
           (#(java.lang.String. %))
           json/parse-string
-          remove-nil-vals
+          remove-empty-vals
           (#(namespace-invoice-keys :boostagram %))
           (#(flatten-paths "/" %))))
     (catch Exception e (println "EXCEPTION DECODING BOOST: " rawboost debug (bean e)) {})))
@@ -210,10 +227,12 @@
                   (assoc
                    invoice
                    :boostagram/value_sat_total
-                   (/ msats 1000))
+                   (quot msats 1000))
                   invoice)
         ;; Add attempt at content-derived ID
-        invoice (assoc invoice :boostagram/content_id (content-id invoice))]
+        invoice (assoc invoice :boostagram/content_id (content-id invoice))
+        ;; Classify as sat-based (all LND/Alby invoices)
+        invoice (assoc invoice :boostagram/type :sat)]
     invoice))
 
 (defn process-batch [batch]
@@ -221,10 +240,23 @@
         (comp (map #(dissoc % :features :amp_invoice_state :metadata :custom_records))
               (map #(namespace-invoice-keys :invoice %1))
               (map #(flatten-paths "/" %1))
-              (map remove-nil-vals)
+              (map remove-empty-vals)
               (map coerce-invoice-vals))
         #_(map #(into (sorted-map) %))
         batch))
+
+(defn backfill-boost-type! [conn]
+  (let [db (d/db conn)
+        eids (d/q '[:find [?e ...]
+                    :where
+                    [?e :boostagram/action _]
+                    (not [?e :boostagram/type _])]
+                  db)
+        txdata (mapv (fn [eid] {:db/id eid :boostagram/type :sat}) eids)]
+    (when (seq txdata)
+      (println "Backfilling :boostagram/type for" (count txdata) "entities")
+      (d/transact! conn txdata)
+      (println "Backfill complete."))))
 
 (defn add-boosts [conn source-name boosts]
   (->> boosts

--- a/src/boost_scraper/price_feed.clj
+++ b/src/boost_scraper/price_feed.clj
@@ -1,0 +1,66 @@
+(ns boost-scraper.price-feed
+  (:require [babashka.http-client :as http]
+            [cheshire.core :as json]))
+
+(def ^:private sources
+  [{:name "mempool.space" :url "https://mempool.space/api/v1/prices"
+    :parser (fn [body] (some-> body (json/parse-string true) :USD))}
+   {:name "CoinGecko" :url "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd"
+    :parser (fn [body] (some-> body (json/parse-string true) :bitcoin :usd))}
+   {:name "blockchain.info" :url "https://blockchain.info/ticker"
+    :parser (fn [body] (some-> body (json/parse-string true) :USD :last))}])
+
+(defonce ^:private cache (atom {:rate nil :updated-at 0}))
+
+(def ^:private ^:const cache-ttl-ms 300000)
+
+(def ^:private ^:const http-timeout-ms 5000)
+
+(defn- try-source
+  [source]
+  (try
+    (let [resp (http/get (:url source)
+                         {:as :string
+                          :timeout http-timeout-ms
+                          :headers {"User-Agent" "lnd-boost-scraper/1.0"
+                                    "Accept" "application/json"}})
+          body (:body resp)
+          rate ((:parser source) body)]
+      (if (and rate (pos? rate))
+        (do (println "Price feed: got BTC/USD" rate "from" (:name source))
+            {:rate rate :source (:name source)})
+        (do (println "Price feed:" (:name source) "returned invalid rate:" rate)
+            nil)))
+    (catch Exception e
+      (println "Price feed:" (:name source) "error:" (.getMessage e))
+      nil)))
+
+(defn- fetch-btc-usd
+  []
+  (some try-source sources))
+
+(defn get-btc-usd
+  "Return {:rate N :source NAME} with in-memory 5min cache.
+   Falls back through multiple sources if one fails.
+   Returns nil if all sources fail and no cached rate."
+  []
+  (let [{:keys [rate updated-at]} @cache
+        now (System/currentTimeMillis)]
+    (if (and rate (< (- now updated-at) cache-ttl-ms))
+      rate
+      (let [new-result (fetch-btc-usd)]
+        (if new-result
+          (do (swap! cache assoc :rate new-result :updated-at now)
+              new-result)
+          (do (if rate
+                (println "Price feed: all sources failed, using stale rate" (:rate rate)
+                         "from" (:source rate) "at" (str (java.time.Instant/ofEpochMilli updated-at)))
+                (println "Price feed: all sources failed, no cached rate available"))
+              rate))))))
+
+(defn fiat-sats-rate
+  "Return {:rate N :source NAME} where rate is sats per 1 USD.
+   Returns nil if price unavailable."
+  []
+  (when-let [{:keys [rate source]} (get-btc-usd)]
+    {:rate (int (/ 100000000 rate)) :source source}))

--- a/src/boost_scraper/reports.clj
+++ b/src/boost_scraper/reports.clj
@@ -1,6 +1,5 @@
 (ns boost-scraper.reports
   (:require [boost-scraper.utils :as utils]
-            [boost-scraper.schemas :as schemas]
             [clojure.instant]
             [clojure.string :as str]
             [clojure.pprint :as pprint]
@@ -13,6 +12,8 @@
    [:ballers {:default []} [:vector [:map {:closed false}]]]
    [:boosts {:default []} [:vector [:map {:closed false}]]]
    [:thanks {:default []} [:vector [:map {:closed false}]]]
+   [:fiat-boosts {:default []} [:vector [:map {:closed false}]]]
+   [:member-free-boosts {:default []} [:vector [:map {:closed false}]]]
    [:boost-summary
     [:map
      [:boost_total_sats {:default 0} :int]
@@ -52,7 +53,10 @@
                            :boostagram/episode
                            :boostagram/app_name
                            :boostagram/message
-                           :boostagram/ts])
+                           :boostagram/ts
+                           :boostagram/amount_fiat_cents
+                           :boostagram/amount_fiat_currency
+                           :boostagram/payment_rail])
          :in $ ?regex' ?last-seen-timestamp'
          :where
          [?e :invoice/creation_date ?creation_date]
@@ -69,7 +73,7 @@
        (d/db conn) show-regex last-seen-timestamp))
 
 (defn get-boost-summary-for-report [conn show-regex last-seen-timestamp]
-  (d/q '[:find [?ballers ?boosts ?thanks ?summary ?stream_summary ?total_summary ?last_seen_id]
+  (d/q '[:find [?ballers ?boosts ?thanks ?fiat_by_sender ?member_free_by_sender ?summary ?stream_summary ?total_summary ?last_seen_id ?source_sat ?source_fiat ?source_member]
          :in $ ?regex ?last-seen-timestamp
          :where
          ;; find all invoices since last-seen for show-regex
@@ -114,6 +118,12 @@
                 [(re-matches ?regex' ?episode) _])]
            $ ?regex ?last-seen-timestamp)
           ?valid_eids]
+         ;; NOTE: ?valid_eids intentionally includes fiat and member-free
+         ;; entities — no [:boostagram/type :sat] filter here. This means
+         ;; ?last_seen_id (max creation_date) spans all boost types, which
+         ;; is correct: we want the cursor to advance past every processed
+         ;; entity regardless of type. The type-specific aggregation rules
+         ;; below filter by :sat / :fiat / :member-free respectively.
          ;; find max boost creation_date
          [(datalevin.core/q
            [:find [(max ?cd')]
@@ -139,12 +149,13 @@
             :in $ [[?e] ...]
             :where
             [?e :boostagram/action "boost"]
+            [?e :boostagram/type :sat]
             [?e :boostagram/sender_name_normalized ?sender_name_normalized]
             [?e :boostagram/value_sat_total ?sats]
             [?e :invoice/creation_date ?d]]
            $ ?valid_eids_before_maxcd)
           ?sats_by_eid]
-         ;; pull individual boost data for each sender
+          ;; pull individual boost data for each sender
          [(datalevin.core/q
            [:find ?sender_name_normalized' ?sat_total' ?boost_count' ?first_boost' ?boosts
             :in $ [[?sender_name_normalized' ?sat_total' ?boost_count' ?first_boost' ?boost_ids] ...]
@@ -160,7 +171,10 @@
                                    :invoice/creation_date
                                    :invoice/identifier
                                    :boostagram/message
-                                   :scraper/source]) ...]
+                                   :scraper/source
+                                   :boostagram/amount_fiat_cents
+                                   :boostagram/amount_fiat_currency
+                                   :boostagram/payment_rail]) ...]
                :in $ [?e' ...]]
               $ ?boost_ids)
              ?boosts]]
@@ -191,14 +205,75 @@
             [(< ?sat_total' 2000)]]
            $ ?sats_by_eid_with_deets)
           ?thanks]
-         ;; boost summary
+          ;; fiat: aggregate cents by sender
+         [(datalevin.core/q
+           [:find ?sender (sum ?cents) (count ?e) (distinct ?e)
+            :in $ [[?e] ...]
+            :where
+            [?e :boostagram/type :fiat]
+            [?e :boostagram/sender_name_normalized ?sender]
+            [?e :boostagram/amount_fiat_cents ?cents]]
+           $ ?valid_eids_before_maxcd)
+          ?fiat_raw]
+          ;; fiat: pull boost details per sender
+         [(datalevin.core/q
+           [:find ?sender' ?cent_total' ?boost_count' ?boosts
+            :in $ [[?sender' ?cent_total' ?boost_count' ?boost_ids] ...]
+            :where
+            [(datalevin.core/q
+              [:find [(d/pull ?e [:boostagram/sender_name_normalized
+                                  :boostagram/amount_fiat_cents
+                                  :boostagram/amount_fiat_currency
+                                  :boostagram/payment_rail
+                                  :boostagram/podcast
+                                  :boostagram/episode
+                                  :boostagram/message
+                                  :invoice/creation_date
+                                  :invoice/created_at
+                                  :scraper/source]) ...]
+               :in $ [?e ...]]
+              $ ?boost_ids)
+             ?boosts]]
+           $ ?fiat_raw)
+          ?fiat_by_sender]
+          ;; member-free: count by sender
+         [(datalevin.core/q
+           [:find ?sender (count ?e) (distinct ?e)
+            :in $ [[?e] ...]
+            :where
+            [?e :boostagram/type :member-free]
+            [?e :boostagram/sender_name_normalized ?sender]]
+           $ ?valid_eids_before_maxcd)
+          ?member_free_raw]
+          ;; member-free: pull boost details per sender
+         [(datalevin.core/q
+           [:find ?sender' ?boost_count' ?boosts
+            :in $ [[?sender' ?boost_count' ?boost_ids] ...]
+            :where
+            [(datalevin.core/q
+              [:find [(d/pull ?e [:boostagram/sender_name_normalized
+                                  :boostagram/payment_rail
+                                  :boostagram/memberful_member_id
+                                  :boostagram/podcast
+                                  :boostagram/episode
+                                  :boostagram/message
+                                  :invoice/creation_date
+                                  :invoice/created_at
+                                  :scraper/source]) ...]
+               :in $ [?e ...]]
+              $ ?boost_ids)
+             ?boosts]]
+           $ ?member_free_raw)
+          ?member_free_by_sender]
+          ;; boost summary (sat only)
          [(datalevin.core/q
            [:find (sum ?sats) (count ?e) (count-distinct ?sender)
             :in $ [[?e] ...]
             :where
-                ;; boost only
+                 ;; boost only
             [?e :boostagram/action "boost"]
-                ;; bind our vars to aggregate
+            [?e :boostagram/type :sat]
+                 ;; bind our vars to aggregate
             [?e :boostagram/value_sat_total ?sats]
             [?e :boostagram/sender_name_normalized ?sender]]
            $ ?valid_eids_before_maxcd)
@@ -230,26 +305,83 @@
            $ ?valid_eids_before_maxcd)
           ?total_summary']
          ;; handle empty results. having a nil here short circuits the whole query
-         [(or (first ?total_summary') [0 0 0]) ?total_summary]]
+         [(or (first ?total_summary') [0 0 0]) ?total_summary]
+         ;; source breakdown: sat boosts grouped by :scraper/source
+         [(datalevin.core/q
+           [:find ?source (sum ?sats) (count ?e)
+            :in $ [[?e] ...]
+            :where
+            [?e :boostagram/type :sat]
+            [?e :boostagram/value_sat_total ?sats]
+            [(get-else $ ?e :scraper/source "unknown") ?source]]
+           $ ?valid_eids_before_maxcd)
+          ?source_sat]
+         ;; source breakdown: fiat boosts grouped by :scraper/source
+         [(datalevin.core/q
+           [:find ?source (sum ?cents) (count ?e)
+            :in $ [[?e] ...]
+            :where
+            [?e :boostagram/type :fiat]
+            [?e :boostagram/amount_fiat_cents ?cents]
+            [(get-else $ ?e :scraper/source "unknown") ?source]]
+           $ ?valid_eids_before_maxcd)
+          ?source_fiat]
+         ;; source breakdown: member-free boosts grouped by :scraper/source
+         [(datalevin.core/q
+           [:find ?source (count ?e)
+            :in $ [[?e] ...]
+            :where
+            [?e :boostagram/type :member-free]
+            [(get-else $ ?e :scraper/source "unknown") ?source]]
+           $ ?valid_eids_before_maxcd)
+          ?source_member]]
        (d/db conn) show-regex last-seen-timestamp))
 
 (defn sort-report
-  [[ballers
-    boosts
-    thanks
+  [[ballers boosts thanks fiat-by-sender member-free-by-sender
     [boost_total_sats boost_total_boosts boost_total_boosters]
     [stream_total_sats stream_total_streams stream_total_streamers]
     [total_sats total_invoices total_unique_boosters]
-    last_seen_id]]
+    last_seen_id
+    source_sat source_fiat source_member]]
   (letfn [(sort-boosts [[sender total count mindate boosts]]
             {:sender sender
              :total total
              :count count
              :mindate mindate
-             :boosts (sort-by :invoice/created_at boosts)})]
+             :boosts (sort-by :invoice/created_at boosts)})
+          (sort-fiat [[sender total count boosts]]
+            {:sender sender
+             :total total
+             :count count
+             :boosts (sort-by :invoice/created_at boosts)})
+          (sort-free [[sender count boosts]]
+            {:sender sender
+             :count count
+             :boosts (sort-by :invoice/created_at boosts)})
+          (merge-source-breakdown [sat-results fiat-results member-results]
+            (let [sat-map (into {} (for [[src sats cnt] sat-results]
+                                     [src {:sats (or sats 0) :count (or cnt 0)}]))
+                  fi-map (into {} (for [[src cents cnt] fiat-results]
+                                    [src {:fiat-cents (or cents 0) :count (or cnt 0)}]))
+                  mem-map (into {} (for [[src cnt] member-results]
+                                     [src {:count (or cnt 0)}]))
+                  all-sources (distinct (concat (keys sat-map) (keys fi-map) (keys mem-map)))]
+              (into (sorted-map)
+                    (for [src all-sources
+                          :let [sat (get-in sat-map [src :sats] 0)
+                                sat-cnt (get-in sat-map [src :count] 0)
+                                fi-cents (get-in fi-map [src :fiat-cents] 0)
+                                fi-cnt (get-in fi-map [src :count] 0)
+                                mem-cnt (get-in mem-map [src :count] 0)]]
+                      [src {:count (+ sat-cnt fi-cnt mem-cnt)
+                            :sats sat
+                            :fiat-cents fi-cents}]))))]
     {:ballers (sort-by :total #(compare %2 %1) (map sort-boosts ballers))
      :boosts (sort-by :mindate (map sort-boosts boosts))
      :thanks (sort-by :mindate (map sort-boosts thanks))
+     :fiat-boosts (sort-by :total #(compare %2 %1) (map sort-fiat fiat-by-sender))
+     :member-free-boosts (sort-by :count #(compare %2 %1) (map sort-free member-free-by-sender))
      :boost-summary {:boost_total_sats (or boost_total_sats 0)
                      :boost_total_boosts (or boost_total_boosts 0)
                      :boost_total_boosters (or boost_total_boosters 0)}
@@ -259,9 +391,25 @@
      :summary {:total_sats (or total_sats 0)
                :total_invoices (or total_invoices 0)
                :last_seen_id last_seen_id
-               :total_unique_boosters (or total_unique_boosters 0)}}))
+               :total_unique_boosters (or total_unique_boosters 0)}
+     :source-breakdown (merge-source-breakdown source_sat source_fiat source_member)}))
 
 (defn int-comma [n] (clojure.pprint/cl-format nil "~:d" (or n 0)))
+
+(defn format-value-line
+  "Format a boost's value line.
+   Fiat: '$5.00 (card)'. Member-free: 'Free'. Sats: '5,000 sats'."
+  [b]
+  (cond
+    (and (:boostagram/amount_fiat_cents b)
+         (pos? (:boostagram/amount_fiat_cents b)))
+    (let [dollars (/ (:boostagram/amount_fiat_cents b) 100.0)
+          rail (or (:boostagram/payment_rail b) "unknown")]
+      (format "$%.2f (%s)" (double dollars) rail))
+    (= "member-free" (:boostagram/payment_rail b))
+    "Free Member Boost"
+    :else
+    (str (int-comma (:boostagram/value_sat_total b)) " sats")))
 
 (defn score-metadata
   "Score a boost by richness of metadata.
@@ -290,7 +438,6 @@
      "\n"
      (concat
       (let [{:keys [boostagram/message
-                    boostagram/value_sat_total
                     boostagram/podcast
                     boostagram/episode
                     boostagram/app_name
@@ -309,15 +456,21 @@
               (str "+ at " (if (string? display-ts) display-ts (utils/format-seconds display-ts)) "\n")))
           "\n"
           "+ " (utils/format-date creation_date) " (" creation_date ")" "\n"
-          "+ " (int-comma value_sat_total) " sats\n"
+          "+ " (format-value-line best) "\n"
           (str/join "\n" (map #(str "> " %) (str/split-lines (or message "No Message Found :(")))))])
       (for [{:keys [boostagram/message boostagram/value_sat_total
                     invoice/creation_date
-                    #_invoice/identifier]} others]
+                    #_invoice/identifier
+                    boostagram/amount_fiat_cents
+                    boostagram/amount_fiat_currency
+                    boostagram/payment_rail]} others]
         (str "\n"
              #_("+ " identifier "\n")
              "+ " (utils/format-date creation_date) " (" creation_date ")" "\n"
-             "+ " (int-comma value_sat_total) " sats\n"
+             "+ " (format-value-line {:boostagram/amount_fiat_cents amount_fiat_cents
+                                      :boostagram/amount_fiat_currency amount_fiat_currency
+                                      :boostagram/payment_rail payment_rail
+                                      :boostagram/value_sat_total value_sat_total}) "\n"
              (str/join "\n" (map #(str "> " %) (str/split-lines (or message "No Message Found :("))))))))))
 
 (defn format-boost-batch [{:keys [sender total count boosts]}]
@@ -327,17 +480,44 @@
        (format-boost-batch-details boosts)
        "\n"))
 
+(defn format-fiat-boost-batch [{:keys [sender total count boosts]}]
+  (str "### From: " sender "\n"
+       "+ " (format "%.2f" (float (/ (or total 0) 100))) " total fiat\n"
+       "+ " (int-comma count) " boost(s)\n"
+       (format-boost-batch-details boosts)
+       "\n"))
+
+(defn format-member-free-boost-batch [{:keys [sender count boosts]}]
+  (str "### From: " sender "\n"
+       "+ " (int-comma count) " free member boost(s)\n"
+       (format-boost-batch-details boosts)
+       "\n"))
+
 (defn format-boost-section [boosts]
   (str/join "\n" (map format-boost-batch boosts)))
 
+(defn format-fiat-section [boosts]
+  (str/join "\n" (map format-fiat-boost-batch boosts)))
+
+(defn format-member-free-section [boosts]
+  (str/join "\n" (map format-member-free-boost-batch boosts)))
+
 (defn format-sorted-report
-  [{:keys [ballers boosts thanks boost-summary stream-summary summary]}]
+  [{:keys [ballers boosts thanks fiat-boosts member-free-boosts
+           boost-summary stream-summary summary fiat-converted fiat-skipped
+           source-breakdown]}]
   (str "## Baller Boosts\n"
        (format-boost-section ballers) "\n"
        "## Boosts\n"
        (format-boost-section boosts) "\n"
        "## Thanks\n"
        (format-boost-section thanks)
+       (when (seq fiat-boosts)
+         (str "\n## Fiat Boosts\n"
+              (format-fiat-section fiat-boosts)))
+       (when (seq member-free-boosts)
+         (str "\n## Member Free Boosts\n"
+              (format-member-free-section member-free-boosts)))
        "\n## Boost Summary"
        "\n+ Total Boosted Sats: " (int-comma (:boost_total_sats boost-summary))
        "\n+ Total Boosts: " (int-comma (:boost_total_boosts boost-summary))
@@ -350,61 +530,105 @@
        "\n"
        "\n## Summary"
        "\n+ Total Sats: " (int-comma (:total_sats summary))
+       (cond
+         fiat-converted
+         (str " (incl. " (int-comma (:fiat-sats fiat-converted))
+              " fiat @" (int-comma (:rate fiat-converted)) " sats/USD"
+              ", via " (:source fiat-converted) ")")
+         fiat-skipped
+         " (rate unavailable — fiat excluded)")
        "\n+ Total Invoices: " (int-comma (:total_invoices summary))
        "\n+ Total Unique Senders: " (int-comma (:total_unique_boosters summary))
+       (let [fiat-count (apply + (map :count fiat-boosts))
+             fiat-senders (count fiat-boosts)
+             free-count (apply + (map :count member-free-boosts))
+             free-senders (count member-free-boosts)]
+         (str
+          (when (pos? fiat-count)
+            (str "\n+ Total Fiat Boosts: " (int-comma fiat-count)
+                 " (" (int-comma fiat-senders) " booster"
+                 (when (not= 1 fiat-senders) "s") ")"))
+          (when (pos? free-count)
+            (str "\n+ Total Member Free Boosts: " (int-comma free-count)
+                 " (" (int-comma free-senders) " member"
+                 (when (not= 1 free-senders) "s") ")"))))
+       (when (seq source-breakdown)
+         (str "\n\n## Source Breakdown\n"
+              (str/join "\n"
+                        (for [[src {:keys [count sats fiat-cents]}] (reverse (sort-by (fn [[_ v]] (:count v)) source-breakdown))]
+                          (str "+ " src ": " (int-comma count) " boost"
+                               (when (not= 1 count) "s")
+                               " — " (int-comma sats) " sats"
+                               (when (pos? fiat-cents)
+                                 (str ", $" (format "%.2f" (/ fiat-cents 100.0)) " fiat")))))))
        "\n"
        "\n## Last Seen"
        "\n+ Last seen ID: " (:last_seen_id summary)
        "\n"))
 
-(defn boost-report [conn show-regex last-seen-id]
+(defn add-fiat-to-total
+  "Convert fiat boost totals to sats and add to summary total.
+   fiat-sats-rate = {:rate N :source NAME} where rate is sats per 1 USD,
+   nil if no feed configured, or a map with nil rate if feed failed."
+  [report fiat-sats-rate]
+  (let [rate (:rate fiat-sats-rate)]
+    (cond
+      (and rate (seq (:fiat-boosts report)))
+      (let [fiat-cents (apply + (map :total (:fiat-boosts report)))
+            fiat-sats (int (/ (* fiat-cents (long rate)) 100))]
+        (-> report
+            (assoc :fiat-converted {:fiat-cents fiat-cents
+                                    :fiat-sats fiat-sats
+                                    :rate rate
+                                    :source (:source fiat-sats-rate)})
+            (update-in [:summary :total_sats] + fiat-sats)))
+      (and (map? fiat-sats-rate) (nil? rate) (seq (:fiat-boosts report)))
+      (assoc report :fiat-skipped true)
+      :else report)))
+
+(defn boost-report [conn show-regex last-seen-id & {:keys [fiat-sats-rate]}]
   (->> (get-boost-summary-for-report conn show-regex last-seen-id)
        sort-report
        normalize-report
+       (#(add-fiat-to-total % fiat-sats-rate))
        format-sorted-report))
 
 (defn first-booster [conn episode]
-  (d/q '[:find [(d/pull ?entity [:boostagram/sender_name ;; what fields we want to see on the entity
-                                 :invoice/created_at
-                                 :boostagram/app_name
-                                 :boostagram/value_sat_total])]
-         :in $ ?episode
-       ;; find entity id for first stream that matches our filters
-         :where [(d/q [:find [(min ?timestamp) ?entity]
-                       :where
-                     ;; find only streams
-                       [?entity :boostagram/action "stream"]
-                     ;; for a particular episode
-                       [?entity :boostagram/episode ?episode]
-                     ;; bind creation_date to ?timestamp
-                       [?entity :invoice/creation_date ?timestamp]]
-                      $)
-                 [_ ?entity]]]
-       (d/db conn)
-       episode))
+  (let [db (d/db conn)
+        [min-ts]
+        (d/q '[:find [(min ?timestamp)]
+               :in $ ?episode
+               :where
+               [?e :boostagram/action "stream"]
+               [?e :boostagram/episode ?episode]
+               [?e :invoice/creation_date ?timestamp]]
+             db episode)]
+    (when min-ts
+      (first
+       (d/q '[:find [(pull ?e [:boostagram/sender_name
+                               :invoice/created_at
+                               :boostagram/app_name
+                               :boostagram/value_sat_total])]
+              :in $ ?episode ?min-ts
+              :where
+              [?e :boostagram/action "stream"]
+              [?e :boostagram/episode ?episode]
+              [?e :invoice/creation_date ?min-ts]]
+            db episode min-ts)))))
 
 (defn podcast-app-percentages [conn]
-  (d/q '[:find ?app ?prcnt
-         :in $
-         :order-by [?prcnt :desc]
-         :where
-         [(datalevin.core/q [:find ?app (count ?e)
-                             :in $
-                             :where
-                             [?e :boostagram/action "boost"]
-                             [(get-else $ ?e :boostagram/app_name "unknown_app") ?app]]
-                            $)
-          ?appcnts]
-         [(datalevin.core/q [:find [(sum ?cnt)]
-                             :in [[_ ?cnt]]]
-                            ?appcnts)
-          [?total]]
-         [(datalevin.core/q [:find ?app ?prcnt
-                             :in ?total [[?app ?cnt] ...]
-                             :where
-                             [(/ ?cnt ?total) ?prcnt']
-                             [(* 100.0 ?prcnt') ?prcnt'']
-                             [(clojure.math/round ?prcnt'') ?prcnt]]
-                            ?total ?appcnts)
-          [[?app ?prcnt] ...]]]
-       (d/db conn)))
+  (let [db (d/db conn)
+        ;; Query all boosts with their app_name (get-else for missing)
+        app-counts (d/q '[:find ?app (count ?e)
+                          :in $
+                          :where
+                          [?e :boostagram/action "boost"]
+                          [(get-else $ ?e :boostagram/app_name "unknown_app") ?app]]
+                        db)
+        total (apply + (map second app-counts))]
+    (if (pos? total)
+      (sort-by second #(compare %2 %1)
+               (map (fn [[app cnt]]
+                      [app (long (Math/round (* (/ cnt total) 100.0)))])
+                    app-counts))
+      [])))

--- a/src/boost_scraper/schemas.clj
+++ b/src/boost_scraper/schemas.clj
@@ -1,6 +1,5 @@
 (ns boost-scraper.schemas
-  (:require [malli.core :as m]
-            [malli.util :as mu]))
+  (:require [malli.util :as mu]))
 
 (def ClientState
   [:map
@@ -24,7 +23,13 @@
    [:boostagram/action :string]
    [:boostagram/message {:optional true} :string]
    [:boostagram/value_sat_total :long]
-   [:scraper/source {:optional true} :string]])
+   [:scraper/source {:optional true} :string]
+   [:boostagram/payment_rail {:optional true} :string]
+   [:boostagram/amount_fiat_cents {:optional true} :long]
+   [:boostagram/amount_fiat_currency {:optional true} :string]
+   [:boostagram/received_at {:optional true} inst?]
+   [:boostagram/podcast_slug {:optional true} :string]
+   [:boostagram/episode_guid {:optional true} :string]])
 
 (defn as-optional [schema]
   (mu/optional-keys schema))

--- a/src/boost_scraper/upstream/lnd.clj
+++ b/src/boost_scraper/upstream/lnd.clj
@@ -2,8 +2,7 @@
   (:require [babashka.http-client :as http]
             [boost-scraper.upstream :as upstream]
             [boost-scraper.utils :as utils]
-            [cheshire.core :as json]
-            [clojure.math :as math]))
+            [cheshire.core :as json]))
 
 ;; macaroon -> hex
 (defn- get-path [pathstr]
@@ -17,27 +16,6 @@
       javax.xml.bind.DatatypeConverter/printHexBinary
       (#(.toLowerCase %))))
 
-(defn with-retries [f & {:keys [max-retries base-delay-ms] :or {max-retries 3 base-delay-ms 1000}}]
-  (loop [attempt 1]
-    (let [result (try
-                   {:ok (f)}
-                   (catch Exception e
-                     (if (< attempt max-retries)
-                       {:retry e}
-                       {:error e})))]
-      (if-let [e (:retry result)]
-        (let [;; Exponential backoff: base * 2^(attempt-1)
-              exp-delay (* base-delay-ms (long (math/pow 2 (dec attempt))))
-              ;; Full Jitter: random between 0 and exp-delay
-              jitter-delay (long (rand exp-delay))]
-          (println (format "Attempt %d failed, retrying in %dms (jittered from %dms)... Error: %s"
-                           attempt jitter-delay exp-delay (.getMessage e)))
-          (Thread/sleep jitter-delay)
-          (recur (inc attempt)))
-        (if-let [e (:error result)]
-          (throw e)
-          (:ok result))))))
-
 (defrecord Scraper []
   upstream/IBoostScrape
   (get-boosts [_ {:keys [token wait offset url] :as last_}]
@@ -45,7 +23,7 @@
       (println "still going!" offset url)
       (let [query-params {:reversed true}
             query-params (if offset (assoc query-params :index_offset offset) query-params)
-            data (with-retries
+            data (utils/with-retries
                    (fn []
                      (-> (or url "https://100.115.78.27:8080/v1/invoices")
                          (http/get {:headers {"Grpc-Metadata-macaroon" token}
@@ -54,7 +32,7 @@
                          :body
                          (json/parse-string true))))
             next_ {:next (into last_ {:macaroon token
-                                      :offset (get data :first_index_offset)})
+                                      :offset (get data :last_index_offset)})
 
                    :data (:invoices data)}]
         (try

--- a/src/boost_scraper/upstream/r2.clj
+++ b/src/boost_scraper/upstream/r2.clj
@@ -1,0 +1,138 @@
+(ns boost-scraper.upstream.r2
+  (:require [boost-scraper.db :as db]
+            [boost-scraper.utils :as utils]
+            [cheshire.core :as json]
+            [cognitect.aws.client.api :as aws]
+            [cognitect.aws.credentials :as credentials]
+            [datalevin.core :as d])
+  (:import [java.time Instant]
+           [java.util Date]))
+
+(def ^:private prefix "member-boosts/v1/r/")
+(def ^:private ^:const invoke-timeout-ms 30000)
+
+(defn- invoke-with-timeout
+  "Invoke an AWS operation with a timeout. Throws on timeout."
+  [s3-client op request]
+  (let [result (deref (future (aws/invoke s3-client {:op op :request request}))
+                      invoke-timeout-ms
+                      ::timeout)]
+    (when (= result ::timeout)
+      (throw (ex-info (str "R2 " (name op) " timed out after " invoke-timeout-ms "ms")
+                      {:op op :timeout invoke-timeout-ms})))
+    result))
+
+(defn- make-s3-client
+  "Create an S3 client configured for Cloudflare R2."
+  [{:keys [account-id access-key secret-key]}]
+  (aws/client {:api :s3
+               :region "us-east-1"
+               :credentials-provider
+               (credentials/basic-credentials-provider
+                {:access-key-id access-key
+                 :secret-access-key secret-key})
+               :endpoint-override
+               {:protocol :https
+                :hostname (str account-id ".r2.cloudflarestorage.com")}}))
+
+(defn- list-objects
+  "List objects under prefix. Returns {:keys [...] :next-token ...}."
+  [s3-client bucket start-after continuation-token]
+  (let [req (cond-> {:Bucket bucket :Prefix prefix}
+              start-after (assoc :StartAfter start-after)
+              continuation-token (assoc :ContinuationToken continuation-token))
+        resp (invoke-with-timeout s3-client :ListObjectsV2 req)]
+    (when-let [err (:cognitect.anomalies/category resp)]
+      (throw (ex-info (str "R2 list error: " err " " (:cognitect.aws.cli/message resp))
+                      {:anomaly err :response resp})))
+    {:keys (mapv :Key (:Contents resp))
+     :next-token (:NextContinuationToken resp)
+     :truncated (:IsTruncated resp)}))
+
+(defn- get-object-body
+  "Fetch an object's body as a string."
+  [s3-client bucket key]
+  (let [resp (invoke-with-timeout s3-client :GetObject {:Bucket bucket :Key key})]
+    (when-let [err (:cognitect.anomalies/category resp)]
+      (throw (ex-info (str "R2 get error: " err " " (:cognitect.aws.cli/message resp))
+                      {:anomaly err :response resp})))
+    (slurp (:Body resp))))
+
+(defn process-record
+  "Convert an R2 record into a boost entity for Datalevin.
+
+  See web-boost-worker docs/shared-interface.md §1 for the 10-field schema."
+  [record object-key]
+  (let [created-at (get record :createdAt)
+        created-instant (when created-at (Instant/parse created-at))
+        created-date (when created-instant (Date/from created-instant))
+        created-epoch (when created-instant (.getEpochSecond created-instant))
+        username (get record :username)]
+    {:boostagram/type :member-free
+     :boostagram/r2_object_key object-key
+     :invoice/identifier (str "member-r2-" (get record :boostId))
+     :boostagram/podcast (get record :podcastName)
+     :boostagram/episode (get record :episodeTitle)
+     :boostagram/sender_name username
+     :boostagram/sender_name_normalized (db/normalize-name (or username ""))
+     :boostagram/message (or (get record :message) "")
+     :boostagram/action "boost"
+     :boostagram/value_sat_total 0
+     :boostagram/payment_rail "member-free"
+     :boostagram/memberful_member_id (some-> (get record :memberId) str)
+     :boostagram/app_name "Memberful (Free)"
+     :scraper/source "r2-member"
+     :invoice/creation_date created-epoch
+     :invoice/created_at created-date
+     :boostagram/received_at created-date
+     :boostagram/podcast_slug (get record :podcastSlug)
+     :boostagram/episode_guid (get record :episodeGuid)
+     :boostagram/amount_fiat_cents (get record :amountFiatCents)
+     :boostagram/amount_fiat_currency (get record :amountFiatCurrency "USD")}))
+
+
+(defn sync-r2-boosts!
+  "Fetch new member boosts from the R2 bucket and upsert into nodecan.
+   Lists objects under the flat prefix using start-after cursors.
+   On first run (no cursor), lists everything in the bucket."
+  [nodecan-conn {:keys [account-id access-key secret-key bucket]}]
+  (let [s3 (make-s3-client {:account-id account-id
+                            :access-key access-key
+                            :secret-key secret-key})
+        [cursor-str] (d/q '[:find [?value]
+                              :where [?e :sync-cursor/key "r2-member"]
+                              [?e :sync-cursor/value ?value]]
+                            (d/db nodecan-conn))
+        _ (println "R2 sync starting, cursor:" (or cursor-str "(full scan)")
+                    "| bucket:" bucket
+                    "| key-prefix:" (subs (or access-key "") 0 (min 8 (count (or access-key "")))))
+        total (atom 0)
+        last-key (atom nil)]
+    (loop [start-after cursor-str continuation-token nil]
+      (let [{:keys [keys next-token truncated]}
+            (utils/with-retries
+              (fn [] (list-objects s3 bucket start-after continuation-token)))]
+        (doseq [key keys]
+          (utils/with-retries
+            (fn []
+              (let [body (get-object-body s3 bucket key)]
+                (when body
+                  (let [record (json/parse-string body true)
+                        entity (db/remove-empty-vals (process-record record key))]
+                    (d/transact! nodecan-conn [entity])
+                    (swap! total inc)
+                    (reset! last-key key)))))))
+        ;; Cursor advances only on successful object processing, not on
+        ;; successful listing. If the last page returns keys but every
+        ;; object fetch fails, last-key stays nil and the cursor does not
+        ;; advance — the errored keys will be retried on next sync.
+        (if truncated
+          (recur nil next-token)
+          (when (seq keys)
+            (recur (last keys) nil)))))
+    (when @last-key
+      (d/transact! nodecan-conn [{:sync-cursor/key "r2-member"
+                                   :sync-cursor/value @last-key}])
+      (println "R2 cursor updated to:" @last-key))
+    (println (str "R2 sync complete. Processed " @total " new member boosts."))
+    @total))

--- a/src/boost_scraper/upstream/zaprite.clj
+++ b/src/boost_scraper/upstream/zaprite.clj
@@ -1,0 +1,124 @@
+(ns boost-scraper.upstream.zaprite
+  (:require [babashka.http-client :as http]
+            [boost-scraper.db :as db]
+            [boost-scraper.utils :as utils]
+            [cheshire.core :as json]
+            [clojure.string :as string]
+            [datalevin.core :as d])
+  (:import [java.time Instant]
+           [java.util Date]))
+
+(def zaprite-api-base "https://api.zaprite.com")
+
+(defn fetch-orders
+  "Fetch a page of paid Zaprite orders since cursor.
+   Returns {:items [...] :meta {:page N :pagesCount N}} or nil."
+  [api-key cursor page]
+  (let [query (merge {"status[]" ["PAID" "COMPLETE" "OVERPAID"]
+                      "sortBy" "paidAt"
+                      "sortOrder" "asc"
+                      "page" (str page)}
+                     (when cursor {"paidAtMin" cursor}))
+        url (str zaprite-api-base "/v1/orders")]
+    (utils/with-retries
+      (fn []
+        (-> (http/get url {:headers {"Authorization" (str "Bearer " api-key)}
+                           :query-params query})
+            (utils/check-http-status "Zaprite")
+            :body
+            (json/parse-string true))))))
+
+(defn infer-payment-rail
+  "Map Zaprite transaction method to our payment rail."
+  [order]
+  (if-let [method (get-in order [:transactions 0 :method])]
+    (case method
+      "LIGHTNING" "lightning"
+      "BITCOIN" "onchain"
+      "CARD" "card"
+      "ACH" "ach"
+      "APPLEPAY" "card"
+      "GOOGLEPAY" "card"
+      (string/lower-case method))
+    "unknown"))
+
+(defn process-order
+  "Convert a Zaprite order map into a boost entity for Datalevin."
+  [order]
+  (let [meta (get order :metadata {})
+        currency (get order :currency)
+        total-amount (get order :totalAmount)
+        paid-at (get order :paidAt)
+        paid-instant (when paid-at (Instant/parse paid-at))
+        paid-epoch (when paid-instant (.getEpochSecond paid-instant))
+        paid-date (when paid-instant (Date/from paid-instant))
+        username (get meta :username)
+        podcast-name (get meta :podcastName)
+        episode-title (get meta :episodeTitle)
+        message (get meta :message)]
+    (cond-> {:boostagram/zaprite_order_id (get order :id)
+             :invoice/identifier (str "zaprite-" (get order :id))
+             :boostagram/podcast podcast-name
+             :boostagram/episode episode-title
+             :boostagram/sender_name username
+             :boostagram/sender_name_normalized (db/normalize-name (or username ""))
+             :boostagram/message (or message "")
+             :boostagram/action "boost"
+             :boostagram/payment_rail (infer-payment-rail order)
+             :boostagram/app_name "Zaprite"
+             :scraper/source "zaprite"
+             :invoice/creation_date paid-epoch
+             :invoice/created_at paid-date
+             :boostagram/received_at paid-date
+             :boostagram/podcast_slug (get meta :slug (get meta :podcastSlug))
+             :boostagram/episode_guid (get meta :episodeGuid)
+             :boostagram/memberful_member_id (some-> (get meta :memberId) str)}
+      (= "BTC" currency)
+      (assoc :boostagram/type :sat
+             :boostagram/value_sat_total total-amount)
+
+      (not= "BTC" currency)
+      (assoc :boostagram/type :fiat
+             :boostagram/value_sat_total 0
+             :boostagram/amount_fiat_cents total-amount
+             :boostagram/amount_fiat_currency (or currency "USD")))))
+
+(defn sync-zaprite-boosts!
+  "Fetch new paid orders from Zaprite and upsert into nodecan.
+   Cursor is stored as sync-cursor entity keyed 'zaprite'.
+
+   On first run (no cursor), only fetches the most recent 10 pages (~250 orders)
+   to avoid scanning the entire history."
+  [nodecan-conn api-key]
+  (let [[cursor] (d/q '[:find [?value]
+                        :where [?e :sync-cursor/key "zaprite"]
+                        [?e :sync-cursor/value ?value]]
+                      (d/db nodecan-conn))
+        _ (println "Zaprite sync starting, cursor:" cursor)
+        total (atom 0)
+        new-cursor (atom cursor)
+        max-pages (if cursor 100 10)]
+    (loop [page 1]
+      (when (<= page max-pages)
+        (when-let [resp (fetch-orders api-key cursor page)]
+          (let [items (get resp :items [])
+                meta (get resp :meta {})
+                pages (get meta :pagesCount 1)]
+            (doseq [order items]
+              (let [meta (get order :metadata {})]
+                ;; Only process Zaprite orders that came through the podcast web-boost
+                ;; widget. Direct Zaprite invoice payments (not web-boost) are skipped.
+                (when (= "web-boost" (get meta :app))
+                  (let [entity (db/remove-empty-vals (process-order order))]
+                    (d/transact! nodecan-conn [entity])
+                    (swap! total inc)
+                    (when-let [paid (get order :paidAt)]
+                      (reset! new-cursor (str (-> (Instant/parse paid) (.plusMillis 1)))))))))
+            (when (< page pages)
+              (recur (inc page)))))))
+    (when (and @new-cursor (not= @new-cursor cursor))
+      (d/transact! nodecan-conn [{:sync-cursor/key "zaprite"
+                                  :sync-cursor/value @new-cursor}])
+      (println "Zaprite cursor updated to:" @new-cursor))
+    (println (str "Zaprite sync complete. Processed " @total " new boosts."))
+    @total))

--- a/src/boost_scraper/utils.clj
+++ b/src/boost_scraper/utils.clj
@@ -1,5 +1,6 @@
 (ns boost-scraper.utils
-  (:import [java.util.concurrent CompletableFuture]))
+  (:import [java.util.concurrent CompletableFuture])
+  (:require [clojure.math :as math]))
 
 (defn format-date [unix-time]
   (-> (java.time.Instant/ofEpochSecond unix-time)
@@ -29,6 +30,38 @@
   "Wrap f in a new function that runs f on a virtual thread with apply-virtual."
   [f]
   (fn [& args] (apply-virtual f args)))
+
+(defn with-retries
+  "Execute f with exponential backoff and full jitter.
+   Options: :max-retries (default 3), :base-delay-ms (default 1000)."
+  [f & {:keys [max-retries base-delay-ms] :or {max-retries 3 base-delay-ms 1000}}]
+  (loop [attempt 1]
+    (let [result (try
+                   {:ok (f)}
+                   (catch Exception e
+                     (if (< attempt max-retries)
+                       {:retry e}
+                       {:error e})))]
+      (if-let [e (:retry result)]
+        (let [exp-delay (* base-delay-ms (long (math/pow 2 (dec attempt))))
+              jitter-delay (long (rand exp-delay))]
+          (println (format "Attempt %d failed, retrying in %dms (jittered from %dms)... Error: %s"
+                           attempt jitter-delay exp-delay (.getMessage e)))
+          (Thread/sleep jitter-delay)
+          (recur (inc attempt)))
+        (if-let [e (:error result)]
+          (throw e)
+          (:ok result))))))
+
+(defn check-http-status
+  "Throw if the HTTP response indicates an error.
+   context is a human-readable source name for error messages."
+  [resp context]
+  (let [status (:status resp)]
+    (when (>= status 400)
+      (throw (ex-info (str context " API error: " status " " (:body resp))
+                      {:status status :body (:body resp)}))))
+  resp)
 
 (comment
   (defn seconds-between [inst1 inst2]

--- a/src/boost_scraper/web.clj
+++ b/src/boost_scraper/web.clj
@@ -1,6 +1,7 @@
 (ns boost-scraper.web
   (:require [aleph.http :as http]
             [babashka.http-client :as httpc]
+            [boost-scraper.price-feed :as price-feed]
             [boost-scraper.reports :as reports]
             [boost-scraper.shows :as shows]
             [boost-scraper.client-state :as client-state]
@@ -110,7 +111,8 @@
                   ;; Query results
                   (let [show-pattern (re-pattern show-regex)
                         since resolved-since
-                        report (reports/boost-report db-conn show-pattern since)]
+                        report (reports/boost-report db-conn show-pattern since
+                                                     :fiat-sats-rate (price-feed/fiat-sats-rate))]
                     [:div#boosts {:style {:margin-top "10px" :margin-bottom "10px"}}
                      [:div {:style {"padding" "10px"}}
                       [:button#copyMarkdown {:onClick "copyMarkdown()"} "Copy Markdown"]

--- a/test/boost_scraper/api_test.clj
+++ b/test/boost_scraper/api_test.clj
@@ -1,59 +1,53 @@
 (ns boost-scraper.api-test
   (:require [clojure.test :refer [deftest is testing]]
             [babashka.http-client :as http]
-            [cheshire.core :as json]
-            [clojure.string :as str]))
+            [cheshire.core :as json]))
 
-(def base-url (or (System/getenv "TEST_BASE_URL") "http://100.120.212.39:3223"))
+(when-let [base-url (System/getenv "TEST_BASE_URL")]
+  (defn- get-client-states []
+    (-> (http/get (str base-url "/api/v1/client-states"))
+        :body
+        (json/parse-string true)
+        :client-states))
 
-(defn- get-client-states []
-  (-> (http/get (str base-url "/api/v1/client-states"))
-      :body
-      (json/parse-string true)
-      :client-states))
+  (defn- delete-client-state [client show]
+    (http/delete (str base-url "/api/v1/client-states")
+                 {:query-params {:client client :show show}}))
 
-(defn- delete-client-state [client show]
-  (http/delete (str base-url "/api/v1/client-states")
-               {:query-params {:client client :show show}}))
+  (deftest client-state-lifecycle-test
+    (let [client (str "test-client-" (System/currentTimeMillis))
+          show "lup"]
 
-(deftest client-state-lifecycle-test
-  (let [client (str "test-client-" (System/currentTimeMillis))
-        show "lup"]
+      (testing "Initial state: client does not exist"
+        (let [states (get-client-states)]
+          (is (not (some #(= (:client %) client) states)))))
 
-    (testing "Initial state: client does not exist"
-      (let [states (get-client-states)]
-        (is (not (some #(= (:client %) client) states)))))
+      (testing "First request: creates client state"
+        (let [resp (http/get (str base-url "/boosts")
+                             {:query-params {:json "true" :show show :client client :since "1775604435"}})
+              states (get-client-states)
+              client-state (first (filter #(= (:client %) client) states))]
+          (is (= 200 (:status resp)))
+          (is (some? client-state))
+          (is (= show (:show client-state)))
+          (is (integer? (:last-seen-tx client-state)))))
 
-    (testing "First request: creates client state"
-      (let [resp (http/get (str base-url "/boosts")
-                           {:query-params {:json "true" :show show :client client :since "1775604435"}})
-            data (json/parse-string (:body resp) true)
-            states (get-client-states)
-            client-state (first (filter #(= (:client %) client) states))]
-        (is (= 200 (:status resp)))
-        (is (some? client-state))
-        (is (= show (:show client-state)))
-        (is (integer? (:last-seen-tx client-state)))))
+      (testing "Second request (incremental): uses stored timestamp"
+        (let [states-before (get-client-states)
+              client-state-before (first (filter #(= (:client %) client) states-before))
+              last-seen-before (:last-seen-tx client-state-before)
 
-    (testing "Second request (incremental): uses stored timestamp"
-      (let [states-before (get-client-states)
-            client-state-before (first (filter #(= (:client %) client) states-before))
-            last-seen-before (:last-seen-tx client-state-before)
+              resp (http/get (str base-url "/boosts")
+                             {:query-params {:json "true" :show show :client client}})
 
-            ;; Request without 'since'
-            resp (http/get (str base-url "/boosts")
-                           {:query-params {:json "true" :show show :client client}})
-            data (json/parse-string (:body resp) true)
+              states-after (get-client-states)
+              client-state-after (first (filter #(= (:client %) client) states-after))]
 
-            states-after (get-client-states)
-            client-state-after (first (filter #(= (:client %) client) states-after))]
+          (is (= 200 (:status resp)))
+          (is (>= (:last-seen-tx client-state-after) last-seen-before))))
 
-        (is (= 200 (:status resp)))
-        ;; High water mark should have moved forward or stayed same
-        (is (>= (:last-seen-tx client-state-after) last-seen-before))))
-
-    (testing "Delete client state"
-      (let [resp (delete-client-state client show)
-            states (get-client-states)]
-        (is (= 200 (:status resp)))
-        (is (not (some #(= (:client %) client) states)))))))
+      (testing "Delete client state"
+        (let [resp (delete-client-state client show)
+              states (get-client-states)]
+          (is (= 200 (:status resp)))
+          (is (not (some #(= (:client %) client) states))))))))

--- a/test/boost_scraper/core_test.clj
+++ b/test/boost_scraper/core_test.clj
@@ -1,0 +1,67 @@
+(ns boost-scraper.core-test
+  (:require [boost-scraper.core :as core]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]])
+  (:import [boost_scraper.upstream IBoostScrape]))
+
+(deftest test-get-all-boosts-until-epoch
+  (testing "stops before batch max creation_date < epoch"
+    (let [batch-1 [{:creation_date 200} {:creation_date 100}]
+          batch-2 [{:creation_date 50} {:creation_date 80}]
+          responses (atom [{:data batch-1 :next :page-2}
+                           {:data batch-2 :next nil}])
+          scraper (reify IBoostScrape
+                    (get-boosts [_ _]
+                      (if-let [resp (first @responses)]
+                        (do (swap! responses rest) resp)
+                        {:data [] :next nil})))
+          result (doall (core/get-all-boosts-until-epoch scraper :test-token 150))]
+      (is (empty? @responses))
+      (is (= 1 (count result)))
+      (is (= 2 (count (first result))))))
+  (testing "epoch at exact boundary (<= behavior)"
+    (let [batch [{:creation_date 100}]
+          calls (atom [])
+          scraper (reify IBoostScrape
+                    (get-boosts [_ {:keys [token]}]
+                      (swap! calls conj token)
+                      {:data batch :next nil}))
+          result (doall (core/get-all-boosts-until-epoch scraper :test-token 100))]
+      (is (= 1 (count result)))
+      (is (= 100 (:creation_date (first (first result)))))))
+  (testing "no batches — returns empty"
+    (let [scraper (reify IBoostScrape
+                    (get-boosts [_ _]
+                      {:data [] :next nil}))]
+      (is (empty? (core/get-all-boosts-until-epoch scraper :test-token 100)))))
+  (testing "mixed batch — records without creation_date filtered from max, but kept in output"
+    (let [batch [{:creation_date 200} {:no-creation-date "foo"}]
+          scraper (reify IBoostScrape
+                    (get-boosts [_ _]
+                      {:data batch :next nil}))
+          result (doall (core/get-all-boosts-until-epoch scraper :test-token 100))]
+      (is (= 1 (count result)))
+      (is (= 2 (count (first result))))))
+  (testing "all records lack creation_date — batch excluded (take-while returns nil)"
+    (let [batch [{:no-date 1} {:also-no-date 2}]
+          scraper (reify IBoostScrape
+                    (get-boosts [_ _]
+                      {:data batch :next nil}))]
+      (is (empty? (doall (core/get-all-boosts-until-epoch scraper :test-token 100)))))))
+
+(deftest test-credential-gating
+  (testing "not-empty makes empty string nil (falsy)"
+    (is (nil? (not-empty "")))
+    (is (nil? (not-empty nil)))
+    (is (= "foo" (not-empty "foo"))))
+  (testing "some-> nil / empty / empty-file chain returns nil"
+    (is (nil? (some-> nil not-empty slurp str/trim not-empty)))
+    (is (nil? (some-> "" not-empty slurp str/trim not-empty)))
+    (is (nil? (some-> "/dev/null" not-empty slurp str/trim not-empty))))
+  (testing "and gating — all five must be truthy"
+    (is (nil? (and nil "a" "b" "c" "d")))
+    (is (nil? (and "a" nil "b" "c" "d")))
+    (is (nil? (and "a" "b" nil "c" "d")))
+    (is (nil? (and "a" "b" "c" nil "d")))
+    (is (nil? (and "a" "b" "c" "d" nil)))
+    (is (= "e" (and "a" "b" "c" "d" "e")))))

--- a/test/boost_scraper/db_test.clj
+++ b/test/boost_scraper/db_test.clj
@@ -1,0 +1,443 @@
+(ns boost-scraper.db-test
+  (:require [boost-scraper.db :as db]
+            [boost-scraper.test-utils :as test-utils]
+            [cheshire.core :as json]
+            [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [datalevin.core :as d]))
+
+(deftest test-normalize-name
+  (testing "lowercases and trims"
+    (is (= "wes" (db/normalize-name "Wes")))
+    (is (= "wes" (db/normalize-name "  wes  ")))
+    (is (= "john doe" (db/normalize-name "John Doe"))))
+  (testing "strips leading @"
+    (is (= "wes" (db/normalize-name "@Wes")))
+    (is (= "cj" (db/normalize-name "@CJ")))
+    (is (= "@nested" (db/normalize-name "@@Nested"))))
+  (testing "empty and whitespace"
+    (is (= "" (db/normalize-name "")))
+    (is (= "" (db/normalize-name "  "))))
+  (testing "handles edge cases"
+    (is (= "test_user" (db/normalize-name "Test_User")))
+    (is (= "user@host" (db/normalize-name "User@Host")))))
+
+(deftest test-remove-empty-vals
+  (testing "removes nil and empty string values"
+    (is (= {:b 1 :d "hello"}
+           (db/remove-empty-vals {:a nil :b 1 :c "" :d "hello"}))))
+  (testing "preserves false and 0"
+    (is (= {:a false :b 0}
+           (db/remove-empty-vals {:a false :b 0 :c nil :d ""}))))
+  (testing "empty input"
+    (is (= {} (db/remove-empty-vals {}))))
+  (testing "all nil/empty"
+    (is (= {} (db/remove-empty-vals {:a nil :b ""})))))
+
+(deftest test-sha256
+  (testing "produces consistent hex hash"
+    (is (= (db/sha256 "hello") (db/sha256 "hello")))
+    (is (= "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+           (db/sha256 "hello"))))
+  (testing "different inputs produce different hashes"
+    (is (not= (db/sha256 "hello") (db/sha256 "world")))))
+
+(deftest test-non-divisible-msats
+  (testing "non-divisible msats truncates to integer sats (quot behavior)"
+    (let [result (db/coerce-invoice-vals
+                  {:boostagram/value_msat_total 1234})]
+      (is (instance? Long (:boostagram/value_sat_total result)))
+      (is (= 1 (:boostagram/value_sat_total result)))))
+  (testing "1 msat rounds down to 0 sats"
+    (let [result (db/coerce-invoice-vals
+                  {:boostagram/value_msat_total 1})]
+      (is (= 0 (:boostagram/value_sat_total result))))))
+
+(deftest test-coerce-invoice-vals
+  (testing "LND format: string add_index becomes identifier + int add_index"
+    (let [result (db/coerce-invoice-vals
+                  {:invoice/add_index "453978"
+                   :invoice/creation_date "1722901411"
+                   :boostagram/value_msat_total 5000000
+                   :boostagram/sender_name "Wes"})]
+      (is (= "453978" (:invoice/identifier result)))
+      (is (= 453978 (:invoice/add_index result)))
+      (is (= 1722901411 (:invoice/creation_date result)))
+      (is (= 5000 (:boostagram/value_sat_total result)))
+      (is (= "wes" (:boostagram/sender_name_normalized result)))
+      (is (some? (:boostagram/content_id result)))))
+  (testing "Alby format: created_at string becomes Date"
+    (let [result (db/coerce-invoice-vals
+                  {:invoice/created_at "2026-05-26T12:00:00Z"
+                   :boostagram/value_msat_total 1000000
+                   :boostagram/sender_name "@User"})]
+      (is (instance? java.util.Date (:invoice/created_at result)))
+      (is (= 1000 (:boostagram/value_sat_total result)))
+      (is (= "user" (:boostagram/sender_name_normalized result)))))
+  (testing "Alby format with timezone offset string"
+    (let [result (db/coerce-invoice-vals
+                  {:invoice/created_at "2026-05-26T14:00:00+02:00"
+                   :boostagram/value_msat_total 1000000})]
+      (is (instance? java.util.Date (:invoice/created_at result)))
+      (is (= 1000 (:boostagram/value_sat_total result)))))
+  (testing "minimal input produces defaults"
+    (let [result (db/coerce-invoice-vals
+                  {:boostagram/value_msat_total 50000})]
+      (is (= 50 (:boostagram/value_sat_total result)))
+      (is (some? (:boostagram/content_id result)))
+      (is (nil? (:invoice/identifier result)))
+      (is (nil? (:invoice/created_at result)))))
+  (testing "creation_date without created_at derives created_at"
+    (let [result (db/coerce-invoice-vals
+                  {:invoice/creation_date 1722901411
+                   :boostagram/value_msat_total 100000})]
+      (is (instance? java.util.Date (:invoice/created_at result)))
+      (is (= 100 (:boostagram/value_sat_total result)))))
+  (testing "no sender_name — no sender_name_normalized"
+    (let [result (db/coerce-invoice-vals
+                  {:boostagram/value_msat_total 1000})]
+      (is (nil? (:boostagram/sender_name_normalized result)))))
+  (testing "content_id determinism — same input, same hash"
+    (let [input {:boostagram/action "boost"
+                 :boostagram/app_name "TestApp"
+                 :boostagram/podcast "Test Show"
+                 :boostagram/episode "Test Ep"
+                 :boostagram/sender_name "wes"
+                 :boostagram/value_msat_total 1000000
+                 :boostagram/message "hello"
+                 :boostagram/ts 1722901411}
+          a (db/coerce-invoice-vals input)
+          b (db/coerce-invoice-vals input)]
+      (is (= (:boostagram/content_id a) (:boostagram/content_id b)))))
+  (testing "content_id differs for different actions"
+    (let [boost-input {:boostagram/action "boost" :boostagram/value_msat_total 1000}
+          stream-input {:boostagram/action "stream" :boostagram/value_msat_total 1000}
+          boost-result (db/coerce-invoice-vals boost-input)
+          stream-result (db/coerce-invoice-vals stream-input)]
+      (is (not= (:boostagram/content_id boost-result)
+                (:boostagram/content_id stream-result))))))
+
+(deftest test-decode-boost
+  (testing "decodes known Base64 boostagram"
+    (let [raw-bytes (.getBytes (json/generate-string
+                                {:action "boost"
+                                 :app_name "TestApp"
+                                 :podcast "Test Show"
+                                 :episode "Test Ep"
+                                 :sender_name "wes"
+                                 :value_msat_total 1000000
+                                 :message "hello"
+                                 :ts 1722901411})
+                               "UTF-8")
+          encoded (String. (.encode (java.util.Base64/getEncoder) raw-bytes))
+          result (db/decode-boost encoded "test")]
+      (is (= "boost" (:boostagram/action result)))
+      (is (= "TestApp" (:boostagram/app_name result)))
+      (is (= "Test Show" (:boostagram/podcast result)))
+      (is (= "wes" (:boostagram/sender_name result)))
+      (is (= 1000000 (:boostagram/value_msat_total result)))
+      (is (= "hello" (:boostagram/message result)))
+      (is (= 1722901411 (:boostagram/ts result)))))
+  (testing "returns empty map on invalid base64"
+    (is (= {} (db/decode-boost "not-valid-base64!!!" "test"))))
+  (testing "returns empty map on valid base64 but not JSON"
+    (is (= {} (db/decode-boost (String. (.encode (java.util.Base64/getEncoder)
+                                                 (.getBytes "not-json" "UTF-8")))
+                               "test")))))
+
+(deftest test-decode-keysend
+  (testing "decodes keysend custom record"
+    (let [raw-bytes (.getBytes "some-keysend-data" "UTF-8")
+          encoded (String. (.encode (java.util.Base64/getEncoder) raw-bytes))
+          result (db/decode-keysend encoded "test")]
+      (is (= "some-keysend-data" (:invoice/keysend result)))))
+  (testing "returns empty map on invalid base64"
+    (is (= {} (db/decode-keysend "not-valid!" "test")))))
+
+(deftest test-namespace-invoice-keys
+  (testing "moves non-map values under namespace key (vectors included)"
+    (let [result (db/namespace-invoice-keys :invoice
+                                            {:add_index "123"
+                                             :creation_date "1722901411"
+                                             :htlcs [{:custom_records {"7629169" "abc"}}]})]
+      (is (= {:add_index "123"
+              :creation_date "1722901411"
+              :htlcs [{:custom_records {"7629169" "abc"}}]}
+             (:invoice result)))
+      (is (nil? (:htlcs result)))))
+  (testing "empty input"
+    (is (= {} (db/namespace-invoice-keys :invoice {})))))
+
+(deftest test-flatten-paths
+  (testing "flattens nested keys with separator"
+    (is (= {:invoice/add_index "123"
+            :invoice/creation_date "1722901411"}
+           (db/flatten-paths "/"
+                             {:invoice {:add_index "123"
+                                        :creation_date "1722901411"}}))))
+  (testing "empty nested map preserves key with empty value"
+    (is (= {:invoice {}}
+           (db/flatten-paths "/" {:invoice {}}))))
+  (testing "mixed depth"
+    (is (= {:a/x 1 :a/y 2 :b 3}
+           (db/flatten-paths "/" {:a {:x 1 :y 2} :b 3})))))
+
+(deftest test-process-batch
+  (testing "processes a realistic LND invoice with boostagram"
+    (let [raw-bytes (.getBytes (json/generate-string
+                                {:action "boost"
+                                 :app_name "TestApp"
+                                 :podcast "Test Show"
+                                 :episode "Test Ep"
+                                 :sender_name "wes"
+                                 :value_msat_total 5000000
+                                 :message "hello"
+                                 :ts 1722901411})
+                               "UTF-8")
+          encoded (String. (.encode (java.util.Base64/getEncoder) raw-bytes))
+          invoice {:add_index "123"
+                   :creation_date "1722901411"
+                   :value_msat 5000000
+                   :memo "test"
+                   :settled true
+                   :htlcs [{:custom_records {(keyword "7629169") encoded
+                                             (keyword "34349334") (String. (.encode
+                                                                            (java.util.Base64/getEncoder)
+                                                                            (.getBytes "test-keysend" "UTF-8")))}}]
+                   :features {:some "feature"}
+                   :amp_invoice_state {:some "state"}
+                   :metadata {:some "meta"}
+                   :custom_records {:some "custom"}}
+          result (db/process-batch [invoice])
+          boost (first result)]
+      ;; dissoc removed the unwanted keys
+      (is (not (contains? boost :features)))
+      (is (not (contains? boost :amp_invoice_state)))
+      (is (not (contains? boost :metadata)))
+      (is (not (contains? boost :custom_records)))
+      (is (not (contains? boost :htlcs)))
+      ;; namespace + flatten + coerce produced expected fields
+      (is (= "123" (:invoice/identifier boost)))
+      (is (= 123 (:invoice/add_index boost)))
+      (is (= 1722901411 (:invoice/creation_date boost)))
+      (is (= 5000 (:boostagram/value_sat_total boost)))
+      (is (= "wes" (:boostagram/sender_name boost)))
+      (is (= "wes" (:boostagram/sender_name_normalized boost)))
+      (is (= "boost" (:boostagram/action boost)))
+      (is (= "TestApp" (:boostagram/app_name boost)))
+      (is (= "Test Show" (:boostagram/podcast boost)))
+      (is (= "Test Ep" (:boostagram/episode boost)))
+      (is (= "hello" (:boostagram/message boost)))
+      (is (= 1722901411 (:boostagram/ts boost)))
+      (is (some? (:boostagram/content_id boost)))
+      (is (= :sat (:boostagram/type boost))))))
+
+(deftest test-backfill-boost-type!
+  (let [tmpdir (str "/tmp/test-backfill-" (java.util.UUID/randomUUID))
+        conn (d/get-conn tmpdir db/schema)]
+    (try
+      (d/transact! conn [{:invoice/identifier "b1" :boostagram/action "boost" :boostagram/content_id "c1"}
+                         {:invoice/identifier "b2" :boostagram/action "stream" :boostagram/content_id "c2"}])
+      (db/backfill-boost-type! conn)
+      (let [db (d/db conn)
+            types (d/q '[:find ?id ?t
+                         :where [?e :invoice/identifier ?id]
+                         [?e :boostagram/type ?t]]
+                       db)]
+        (is (= #{["b1" :sat] ["b2" :sat]} (into #{} types))))
+      ;; idempotent — second run makes no changes
+      (db/backfill-boost-type! conn)
+      (let [db (d/db conn)
+            types (d/q '[:find ?id ?t
+                         :where [?e :invoice/identifier ?id]
+                         [?e :boostagram/type ?t]]
+                       db)]
+        (is (= #{["b1" :sat] ["b2" :sat]} (into #{} types))))
+      (finally
+        (d/close conn)
+        (test-utils/delete-dir-recursively (io/file tmpdir))))))
+
+(deftest test-backfill-empty-db
+  (testing "no entities at all — backfill is a no-op"
+    (let [tmpdir (str "/tmp/test-backfill-empty-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)]
+      (try
+        (db/backfill-boost-type! conn)
+        (let [db (d/db conn)
+              all-eids (d/q '[:find [?e ...] :where [?e :boostagram/type _]] db)]
+          (is (empty? all-eids)))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+(deftest test-backfill-all-typed
+  (testing "all entities already have :boostagram/type — no changes"
+    (let [tmpdir (str "/tmp/test-backfill-typed-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)]
+      (try
+        (d/transact! conn
+                     [{:invoice/identifier "t1" :boostagram/action "boost"
+                       :boostagram/type :sat :boostagram/content_id "c1"}
+                      {:invoice/identifier "t2" :boostagram/action "stream"
+                       :boostagram/type :sat :boostagram/content_id "c2"}
+                      {:invoice/identifier "t3" :boostagram/action "boost"
+                       :boostagram/type :fiat :boostagram/content_id "c3"}])
+        (db/backfill-boost-type! conn)
+        (let [db (d/db conn)
+              types (d/q '[:find ?id ?t
+                           :where [?e :invoice/identifier ?id]
+                           [?e :boostagram/type ?t]]
+                         db)]
+          (is (= #{["t1" :sat] ["t2" :sat] ["t3" :fiat]} (into #{} types))))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+(deftest test-backfill-mixed-types
+  (testing "some already typed, some untyped — only untyped get type"
+    (let [tmpdir (str "/tmp/test-backfill-mixed-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)]
+      (try
+        (d/transact! conn
+                     [{:invoice/identifier "pre-typed" :boostagram/action "boost"
+                       :boostagram/type :fiat :boostagram/amount_fiat_cents 1000
+                       :boostagram/content_id "c1"}
+                      {:invoice/identifier "pre-member" :boostagram/action "boost"
+                       :boostagram/type :member-free :boostagram/payment_rail "member-free"
+                       :boostagram/content_id "c2"}
+                      {:invoice/identifier "legacy-1" :boostagram/action "boost"
+                       :boostagram/content_id "c3"}
+                      {:invoice/identifier "legacy-2" :boostagram/action "stream"
+                       :boostagram/content_id "c4"}])
+        (db/backfill-boost-type! conn)
+        (let [db (d/db conn)
+              types (d/q '[:find ?id ?t
+                           :where [?e :invoice/identifier ?id]
+                           [?e :boostagram/type ?t]]
+                         db)]
+          (is (= #{["pre-typed" :fiat]
+                   ["pre-member" :member-free]
+                   ["legacy-1" :sat]
+                   ["legacy-2" :sat]}
+                 (into #{} types))))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+(deftest test-backfill-no-action
+  (testing "entities without :boostagram/action are not touched"
+    (let [tmpdir (str "/tmp/test-backfill-noact-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)]
+      (try
+        (d/transact! conn
+                     [{:sync-cursor/key "zaprite" :sync-cursor/value "2026-01-01"}
+                      {:sync-cursor/key "r2-member" :sync-cursor/value "key-abc"}])
+        (db/backfill-boost-type! conn)
+        (let [db (d/db conn)
+              typed (d/q '[:find [?e ...] :where [?e :boostagram/type _]] db)]
+          (is (empty? typed))
+          (let [cursors (d/q '[:find ?k ?v
+                               :where [?e :sync-cursor/key ?k]
+                               [?e :sync-cursor/value ?v]]
+                             db)]
+            (is (= #{["zaprite" "2026-01-01"] ["r2-member" "key-abc"]}
+                   (into #{} cursors)))))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+(deftest test-backfill-existing-type-preserved
+  (testing "entity with :boostagram/action and existing non-sat type keeps its type"
+    (let [tmpdir (str "/tmp/test-backfill-preserve-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)]
+      (try
+        (d/transact! conn
+                     [{:invoice/identifier "fiat-boost" :boostagram/action "boost"
+                       :boostagram/type :fiat :boostagram/amount_fiat_cents 2500
+                       :boostagram/content_id "c1"}
+                      {:invoice/identifier "free-boost" :boostagram/action "boost"
+                       :boostagram/type :member-free :boostagram/payment_rail "member-free"
+                       :boostagram/memberful_member_id "42"
+                       :boostagram/content_id "c2"}])
+        (db/backfill-boost-type! conn)
+        (let [db (d/db conn)
+              types (d/q '[:find ?id ?t
+                           :where [?e :invoice/identifier ?id]
+                           [?e :boostagram/type ?t]]
+                         db)]
+          (is (= #{["fiat-boost" :fiat] ["free-boost" :member-free]}
+                 (into #{} types))))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+(deftest test-backfill-large-batch
+  (testing "100 untyped entities all get :sat in one backfill"
+    (let [tmpdir (str "/tmp/test-backfill-large-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)
+          entities (vec (for [i (range 100)]
+                          {:invoice/identifier (str "legacy-" i)
+                           :boostagram/action (if (odd? i) "boost" "stream")
+                           :boostagram/value_sat_total (rand-int 50000)
+                           :boostagram/content_id (str "c" i)
+                           :scraper/source "lnd"}))]
+      (try
+        (d/transact! conn entities)
+        (db/backfill-boost-type! conn)
+        (let [db (d/db conn)
+              types (d/q '[:find ?id ?t
+                           :where [?e :invoice/identifier ?id]
+                           [?e :boostagram/type ?t]]
+                         db)]
+          (is (= 100 (count types)))
+          (is (every? (fn [[_id t]] (= :sat t)) types)))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+(deftest test-datalevin-schema-roundtrip
+  (let [tmpdir (str "/tmp/test-schema-roundtrip-" (java.util.UUID/randomUUID))
+        conn (d/get-conn tmpdir db/schema)
+        boost {:invoice/identifier "roundtrip-1"
+               :invoice/creation_date 1722901411
+               :boostagram/sender_name_normalized "testuser"
+               :boostagram/value_sat_total 1000
+               :boostagram/podcast "Test Show"
+               :boostagram/episode "Test Ep"
+               :boostagram/app_name "TestApp"
+               :boostagram/action "boost"
+               :boostagram/content_id "content-id-1"
+               :scraper/source "test"}]
+    (try
+      (d/transact! conn [boost])
+      (let [db (d/db conn)
+            results (d/q '[:find ?v ?id ?c
+                           :where [?e :boostagram/value_sat_total ?v]
+                           [?e :invoice/identifier ?id]
+                           [?e :boostagram/content_id ?c]]
+                         db)]
+        (is (= #{[1000 "roundtrip-1" "content-id-1"]} (into #{} results))))
+      (finally
+        (d/close conn)
+        (test-utils/delete-dir-recursively (io/file tmpdir))))))
+
+(deftest test-cursor-destructuring
+  (testing "cursor read with [:find [?value]] — works with nil and populated"
+    (let [tmpdir (str "/tmp/test-cursor-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)]
+      (try
+        (let [[cursor] (d/q '[:find [?value]
+                               :where [?e :sync-cursor/key "test"]
+                               [?e :sync-cursor/value ?value]]
+                             (d/db conn))]
+          (is (nil? cursor) "no cursor returns nil"))
+        (d/transact! conn [{:sync-cursor/key "test"
+                            :sync-cursor/value "some-cursor-value"}])
+        (let [[cursor] (d/q '[:find [?value]
+                               :where [?e :sync-cursor/key "test"]
+                               [?e :sync-cursor/value ?value]]
+                             (d/db conn))]
+          (is (= "some-cursor-value" cursor) "cursor reads correctly"))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))

--- a/test/boost_scraper/reports_test.clj
+++ b/test/boost_scraper/reports_test.clj
@@ -1,0 +1,1239 @@
+(ns boost-scraper.reports-test
+  (:require [boost-scraper.db :as db]
+            [boost-scraper.reports :as reports]
+            [boost-scraper.test-utils :as test-utils]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [datalevin.core :as d]))
+
+;; ============================================================================
+;; sort-report: 9-element tuple processing
+;; ============================================================================
+
+(deftest test-sort-report-all-positions
+  (testing "all 9 tuple positions fully populated"
+    (let [sat-epoch 2000000000
+          fiat-epoch 2000000010
+          free-epoch 2000000020
+          now (java.util.Date.)
+          baller-boost {:boostagram/sender_name_normalized "big-spender"
+                        :boostagram/value_sat_total 50000
+                        :boostagram/podcast "LINUX Unplugged"
+                        :boostagram/episode "Baller Ep"
+                        :boostagram/app_name "Fountain"
+                        :boostagram/ts 1000
+                        :boostagram/message "Baller boost!"
+                        :invoice/created_at now
+                        :invoice/creation_date sat-epoch
+                        :invoice/identifier "inv-1"
+                        :scraper/source "lnd"}
+          boost-boost {:boostagram/sender_name_normalized "mid-spender"
+                       :boostagram/value_sat_total 10000
+                       :boostagram/podcast "LINUX Unplugged"
+                       :boostagram/episode "Boost Ep"
+                       :boostagram/app_name "Podverse"
+                       :boostagram/message "Mid boost!"
+                       :invoice/created_at now
+                       :invoice/creation_date 2000000005
+                       :invoice/identifier "inv-2"
+                       :scraper/source "lnd"}
+          thanks-boost {:boostagram/sender_name_normalized "small-spender"
+                        :boostagram/value_sat_total 500
+                        :boostagram/podcast "LINUX Unplugged"
+                        :boostagram/episode "Thanks Ep"
+                        :boostagram/app_name "Alby"
+                        :boostagram/message "Thanks!"
+                        :invoice/created_at now
+                        :invoice/creation_date 2000000008
+                        :invoice/identifier "inv-3"
+                        :scraper/source "lnd"}
+          fiat-boost {:boostagram/sender_name_normalized "fiat-user"
+                      :boostagram/value_sat_total 0
+                      :boostagram/amount_fiat_cents 2000
+                      :boostagram/amount_fiat_currency "USD"
+                      :boostagram/payment_rail "card"
+                      :boostagram/podcast "LINUX Unplugged"
+                      :boostagram/episode "Fiat Ep"
+                      :boostagram/app_name "Zaprite"
+                      :boostagram/message "Card payment!"
+                      :invoice/created_at now
+                      :invoice/creation_date fiat-epoch
+                      :scraper/source "zaprite"}
+          member-free {:boostagram/sender_name_normalized "free-user"
+                       :boostagram/value_sat_total 0
+                       :boostagram/payment_rail "member-free"
+                       :boostagram/podcast "LINUX Unplugged"
+                       :boostagram/episode "Free Ep"
+                       :boostagram/app_name "Memberful (Free)"
+                       :boostagram/message "Love the show"
+                       :invoice/created_at now
+                       :invoice/creation_date free-epoch
+                       :scraper/source "r2-member"}
+          raw [[["big-spender" 50000 1 sat-epoch [baller-boost]]]
+               [["mid-spender" 10000 1 2000000005 [boost-boost]]]
+               [["small-spender" 500 1 2000000008 [thanks-boost]]]
+               [["fiat-user" 2000 1 [fiat-boost]]]
+               [["free-user" 1 [member-free]]]
+               [60500 3 3]
+               [0 0 0]
+               [60500 5 5]
+               42
+               [] [] []]
+          result (reports/sort-report raw)]
+      (is (= 1 (count (:ballers result))))
+      (is (= "big-spender" (-> result :ballers first :sender)))
+      (is (= 50000 (-> result :ballers first :total)))
+      (is (= 1 (-> result :ballers first :count)))
+      (is (= 1 (count (:boosts result))))
+      (is (= "mid-spender" (-> result :boosts first :sender)))
+      (is (= 1 (count (:thanks result))))
+      (is (= "small-spender" (-> result :thanks first :sender)))
+      (is (= 1 (count (:fiat-boosts result))))
+      (is (= "fiat-user" (-> result :fiat-boosts first :sender)))
+      (is (= 2000 (-> result :fiat-boosts first :total)))
+      (is (= 1 (count (:member-free-boosts result))))
+      (is (= "free-user" (-> result :member-free-boosts first :sender)))
+      (is (= 1 (-> result :member-free-boosts first :count)))
+      (is (= 60500 (:boost_total_sats (:boost-summary result))))
+      (is (= 3 (:boost_total_boosts (:boost-summary result))))
+      (is (= 3 (:boost_total_boosters (:boost-summary result))))
+      (is (= 0 (:stream_total_sats (:stream-summary result))))
+      (is (= 60500 (:total_sats (:summary result))))
+      (is (= 5 (:total_invoices (:summary result))))
+      (is (= 5 (:total_unique_boosters (:summary result))))
+      (is (= 42 (:last_seen_id (:summary result)))))))
+
+(deftest test-sort-report-empty-fiat-and-member-free
+  (testing "fiat-by-sender and member-free-by-sender positions are empty vectors"
+    (let [now (java.util.Date.)
+          baller-boost {:boostagram/sender_name_normalized "big-spender"
+                        :boostagram/value_sat_total 50000
+                        :boostagram/podcast "LINUX Unplugged"
+                        :boostagram/episode "Baller Ep"
+                        :boostagram/app_name "Fountain"
+                        :boostagram/message "Baller boost!"
+                        :invoice/created_at now
+                        :invoice/creation_date 2000000000
+                        :invoice/identifier "inv-1"
+                        :scraper/source "lnd"}
+          raw [[["big-spender" 50000 1 2000000000 [baller-boost]]] ;; ballers
+               [] ;; boosts (empty)
+               [] ;; thanks (empty)
+               [] ;; fiat-by-sender (empty)
+               [] ;; member-free-by-sender (empty)
+               [50000 1 1] ;; boost-summary
+               [0 0 0] ;; stream-summary
+               [50000 1 1] ;; total-summary
+               nil ;; last-seen-id
+               [] [] []]
+          result (reports/sort-report raw)]
+      (is (= 1 (count (:ballers result))))
+      (is (empty? (:boosts result)))
+      (is (empty? (:thanks result)))
+      (is (empty? (:fiat-boosts result)))
+      (is (empty? (:member-free-boosts result)))
+      (is (= 50000 (:boost_total_sats (:boost-summary result)))))))
+
+(deftest test-sort-report-only-fiat
+  (testing "only fiat boosts present -- no sat-level ballers/boosts/thanks"
+    (let [now (java.util.Date.)
+          fiat-boost {:boostagram/sender_name_normalized "fiat-user"
+                      :boostagram/value_sat_total 0
+                      :boostagram/amount_fiat_cents 1500
+                      :boostagram/amount_fiat_currency "USD"
+                      :boostagram/payment_rail "ach"
+                      :boostagram/podcast "LINUX Unplugged"
+                      :boostagram/episode "Fiat Ep"
+                      :boostagram/app_name "Zaprite"
+                      :boostagram/message "ACH payment"
+                      :invoice/created_at now
+                      :invoice/creation_date 2000000010
+                      :scraper/source "zaprite"}
+          raw [[] [] []
+               [["fiat-user" 1500 1 [fiat-boost]]] ;; fiat-by-sender
+               [] ;; member-free empty
+               [0 0 0] ;; boost-summary (zero -- no sat boosts)
+               [0 0 0] ;; stream-summary
+               [0 1 1] ;; total-summary
+               nil
+               [] [] []]
+          result (reports/sort-report raw)]
+      (is (empty? (:ballers result)))
+      (is (empty? (:boosts result)))
+      (is (empty? (:thanks result)))
+      (is (empty? (:member-free-boosts result)))
+      (is (= 1 (count (:fiat-boosts result))))
+      (is (= "fiat-user" (-> result :fiat-boosts first :sender)))
+      (is (= 1500 (-> result :fiat-boosts first :total)))
+      (is (= 0 (:boost_total_sats (:boost-summary result))))
+      (is (= 0 (:total_sats (:summary result))))
+      (is (= 1 (:total_invoices (:summary result)))))))
+
+(deftest test-sort-report-only-member-free
+  (testing "only member-free boosts present -- no sat or fiat boosts"
+    (let [now (java.util.Date.)
+          mfree-boost {:boostagram/sender_name_normalized "free-user"
+                       :boostagram/value_sat_total 0
+                       :boostagram/payment_rail "member-free"
+                       :boostagram/podcast "LINUX Unplugged"
+                       :boostagram/episode "Free Ep"
+                       :boostagram/app_name "Memberful (Free)"
+                       :boostagram/message "Free boost!"
+                       :invoice/created_at now
+                       :invoice/creation_date 2000000010
+                       :scraper/source "r2-member"}
+          raw [[] [] [] []
+               [["free-user" 1 [mfree-boost]]] ;; member-free-by-sender
+               [0 0 0] ;; boost-summary
+               [0 0 0] ;; stream-summary
+               [0 1 1] ;; total-summary
+               nil
+               [] [] []]
+          result (reports/sort-report raw)]
+      (is (empty? (:ballers result)))
+      (is (empty? (:boosts result)))
+      (is (empty? (:thanks result)))
+      (is (empty? (:fiat-boosts result)))
+      (is (= 1 (count (:member-free-boosts result))))
+      (is (= "free-user" (-> result :member-free-boosts first :sender)))
+      (is (= 1 (-> result :member-free-boosts first :count)))
+      (is (empty? (:fiat-boosts result))))))
+
+(deftest test-sort-report-empty-all
+  (testing "entirely empty result -- all sections empty, nil last-seen-id"
+    (let [raw [[] [] [] [] [] [0 0 0] [0 0 0] [0 0 0] nil [] [] []]
+          result (reports/sort-report raw)]
+      (is (empty? (:ballers result)))
+      (is (empty? (:boosts result)))
+      (is (empty? (:thanks result)))
+      (is (empty? (:fiat-boosts result)))
+      (is (empty? (:member-free-boosts result)))
+      (is (= 0 (:boost_total_sats (:boost-summary result))))
+      (is (= 0 (:stream_total_sats (:stream-summary result))))
+      (is (= 0 (:total_sats (:summary result))))
+      (is (nil? (:last_seen_id (:summary result)))))))
+
+;; ============================================================================
+;; sort-report: fiat detail shape [sender total_cents count [boosts]]
+;; ============================================================================
+
+(deftest test-sort-report-fiat-detail-shape
+  (testing "multiple fiat senders sorted by total descending, boosts by created_at"
+    (let [fiat-a-1 {:boostagram/sender_name_normalized "fiat-user-a"
+                    :boostagram/amount_fiat_cents 1000
+                    :boostagram/amount_fiat_currency "USD"
+                    :boostagram/payment_rail "card"
+                    :boostagram/podcast "LINUX Unplugged"
+                    :boostagram/episode "Ep 1"
+                    :boostagram/message "First card boost"
+                    :invoice/created_at (java.util.Date. 1000000)
+                    :invoice/creation_date 2000000010
+                    :scraper/source "zaprite"}
+          fiat-a-2 {:boostagram/sender_name_normalized "fiat-user-a"
+                    :boostagram/amount_fiat_cents 500
+                    :boostagram/amount_fiat_currency "USD"
+                    :boostagram/payment_rail "card"
+                    :boostagram/podcast "LINUX Unplugged"
+                    :boostagram/episode "Ep 1"
+                    :boostagram/message "Second card boost"
+                    :invoice/created_at (java.util.Date. 2000000)
+                    :invoice/creation_date 2000000020
+                    :scraper/source "zaprite"}
+          fiat-b-1 {:boostagram/sender_name_normalized "fiat-user-b"
+                    :boostagram/amount_fiat_cents 2000
+                    :boostagram/amount_fiat_currency "USD"
+                    :boostagram/payment_rail "ach"
+                    :boostagram/podcast "LINUX Unplugged"
+                    :boostagram/episode "Ep 1"
+                    :boostagram/message "ACH boost"
+                    :invoice/created_at (java.util.Date. 1500000)
+                    :invoice/creation_date 2000000015
+                    :scraper/source "zaprite"}
+          raw [[] [] []
+               [["fiat-user-a" 1500 2 [fiat-a-1 fiat-a-2]]
+                ["fiat-user-b" 2000 1 [fiat-b-1]]]
+               []
+               [0 0 0] [0 0 0] [0 3 2] nil
+               [] [] []]
+          result (reports/sort-report raw)]
+      (is (= 2 (count (:fiat-boosts result))))
+      (is (= "fiat-user-b" (-> result :fiat-boosts first :sender)))
+      (is (= 2000 (-> result :fiat-boosts first :total)))
+      (is (= "fiat-user-a" (-> result :fiat-boosts second :sender)))
+      (is (= 1500 (-> result :fiat-boosts second :total)))
+      (let [boosts-a (-> result :fiat-boosts second :boosts)]
+        (is (= 2 (count boosts-a)))
+        (is (= "First card boost" (:boostagram/message (first boosts-a))))
+        (is (= "Second card boost" (:boostagram/message (second boosts-a))))))))
+
+;; ============================================================================
+;; sort-report: member-free detail shape [sender count [boosts]]
+;; ============================================================================
+
+(deftest test-sort-report-member-free-detail-shape
+  (testing "multiple member-free senders sorted by count descending"
+    (let [free-a-1 {:boostagram/sender_name_normalized "free-user-a"
+                    :boostagram/payment_rail "member-free"
+                    :boostagram/memberful_member_id "100"
+                    :boostagram/podcast "LINUX Unplugged"
+                    :boostagram/episode "Ep 1"
+                    :boostagram/message "First free"
+                    :invoice/created_at (java.util.Date. 1000000)
+                    :invoice/creation_date 2000000010
+                    :scraper/source "r2-member"}
+          free-b-1 {:boostagram/sender_name_normalized "free-user-b"
+                    :boostagram/payment_rail "member-free"
+                    :boostagram/memberful_member_id "200"
+                    :boostagram/podcast "LINUX Unplugged"
+                    :boostagram/episode "Ep 1"
+                    :boostagram/message "Free B-1"
+                    :invoice/created_at (java.util.Date. 1000000)
+                    :invoice/creation_date 2000000020
+                    :scraper/source "r2-member"}
+          free-b-2 {:boostagram/sender_name_normalized "free-user-b"
+                    :boostagram/payment_rail "member-free"
+                    :boostagram/memberful_member_id "200"
+                    :boostagram/podcast "LINUX Unplugged"
+                    :boostagram/episode "Ep 1"
+                    :boostagram/message "Free B-2"
+                    :invoice/created_at (java.util.Date. 2000000)
+                    :invoice/creation_date 2000000030
+                    :scraper/source "r2-member"}
+          raw [[] [] [] []
+               [["free-user-b" 2 [free-b-1 free-b-2]]
+                ["free-user-a" 1 [free-a-1]]]
+               [0 0 0] [0 0 0] [0 3 2] nil
+               [] [] []]
+          result (reports/sort-report raw)]
+      (is (= 2 (count (:member-free-boosts result))))
+      (is (= "free-user-b" (-> result :member-free-boosts first :sender)))
+      (is (= 2 (-> result :member-free-boosts first :count)))
+      (is (= "free-user-a" (-> result :member-free-boosts second :sender)))
+      (is (= 1 (-> result :member-free-boosts second :count)))
+      (let [boosts-b (-> result :member-free-boosts first :boosts)]
+        (is (= "Free B-1" (:boostagram/message (nth boosts-b 0))))
+        (is (= "Free B-2" (:boostagram/message (nth boosts-b 1))))))))
+
+;; ============================================================================
+;; sort-report: multiple sat senders in each bucket
+;; ============================================================================
+
+(deftest test-sort-report-sat-detail-shape
+  (testing "ballers sorted by total descending, boosts/thanks by mindate ascending"
+    (let [now (java.util.Date.)
+          baller-a {:boostagram/sender_name_normalized "baller-a"
+                    :boostagram/value_sat_total 60000
+                    :boostagram/podcast "Test"
+                    :boostagram/episode "Ep"
+                    :boostagram/app_name "App"
+                    :boostagram/message "Biggest baller"
+                    :invoice/created_at now
+                    :invoice/creation_date 1000
+                    :scraper/source "lnd"}
+          baller-b {:boostagram/sender_name_normalized "baller-b"
+                    :boostagram/value_sat_total 30000
+                    :boostagram/podcast "Test"
+                    :boostagram/episode "Ep"
+                    :boostagram/app_name "App"
+                    :boostagram/message "Smaller baller"
+                    :invoice/created_at now
+                    :invoice/creation_date 2000
+                    :scraper/source "lnd"}
+          boost-a {:boostagram/sender_name_normalized "boost-a"
+                   :boostagram/value_sat_total 5000
+                   :boostagram/podcast "Test"
+                   :boostagram/episode "Ep"
+                   :boostagram/app_name "App"
+                   :boostagram/message "Boost A"
+                   :invoice/created_at now
+                   :invoice/creation_date 3000
+                   :scraper/source "lnd"}
+          boost-b {:boostagram/sender_name_normalized "boost-b"
+                   :boostagram/value_sat_total 3000
+                   :boostagram/podcast "Test"
+                   :boostagram/episode "Ep"
+                   :boostagram/app_name "App"
+                   :boostagram/message "Boost B"
+                   :invoice/created_at now
+                   :invoice/creation_date 4000
+                   :scraper/source "lnd"}
+          thanks-a {:boostagram/sender_name_normalized "thanks-a"
+                    :boostagram/value_sat_total 500
+                    :boostagram/podcast "Test"
+                    :boostagram/episode "Ep"
+                    :boostagram/app_name "App"
+                    :boostagram/message "Thanks A"
+                    :invoice/created_at now
+                    :invoice/creation_date 5000
+                    :scraper/source "lnd"}
+          thanks-b {:boostagram/sender_name_normalized "thanks-b"
+                    :boostagram/value_sat_total 100
+                    :boostagram/podcast "Test"
+                    :boostagram/episode "Ep"
+                    :boostagram/app_name "App"
+                    :boostagram/message "Thanks B"
+                    :invoice/created_at now
+                    :invoice/creation_date 6000
+                    :scraper/source "lnd"}
+          raw [[["baller-a" 60000 1 1000 [baller-a]]
+                ["baller-b" 30000 1 2000 [baller-b]]]
+               [["boost-a" 5000 1 3000 [boost-a]]
+                ["boost-b" 3000 1 4000 [boost-b]]]
+               [["thanks-a" 500 1 5000 [thanks-a]]
+                ["thanks-b" 100 1 6000 [thanks-b]]]
+               [] []
+               [98500 6 6] [0 0 0] [98500 6 6] 6000
+               [] [] []]
+          result (reports/sort-report raw)]
+      (is (= "baller-a" (-> result :ballers (nth 0) :sender)))
+      (is (= "baller-b" (-> result :ballers (nth 1) :sender)))
+      (is (= "boost-a" (-> result :boosts (nth 0) :sender)))
+      (is (= "boost-b" (-> result :boosts (nth 1) :sender)))
+      (is (= "thanks-a" (-> result :thanks (nth 0) :sender)))
+      (is (= "thanks-b" (-> result :thanks (nth 1) :sender))))))
+
+;; ============================================================================
+;; format-sorted-report: rendering
+;; ============================================================================
+
+(deftest test-format-sorted-report-all-sections
+  (testing "renders all sections with data"
+    (let [now (java.util.Date.)
+          creation 2000000000
+          sorted {:ballers [{:sender "big-spender"
+                             :total 50000
+                             :count 1
+                             :mindate creation
+                             :boosts [{:boostagram/sender_name_normalized "big-spender"
+                                       :boostagram/value_sat_total 50000
+                                       :boostagram/podcast "LINUX Unplugged"
+                                       :boostagram/episode "Baller Ep"
+                                       :boostagram/app_name "Fountain"
+                                       :boostagram/ts 1000
+                                       :boostagram/message "Baller message!"
+                                       :invoice/creation_date creation
+                                       :invoice/created_at now
+                                       :scraper/source "lnd"}]}]
+                  :boosts [{:sender "mid-spender"
+                            :total 10000
+                            :count 1
+                            :mindate 2000000005
+                            :boosts [{:boostagram/value_sat_total 10000
+                                      :boostagram/message "Mid message"
+                                      :invoice/creation_date 2000000005
+                                      :invoice/created_at now}]}]
+                  :thanks [{:sender "small-spender"
+                            :total 500
+                            :count 1
+                            :mindate 2000000008
+                            :boosts [{:boostagram/value_sat_total 500
+                                      :boostagram/message "Thanks!"
+                                      :invoice/creation_date 2000000008
+                                      :invoice/created_at now}]}]
+                  :fiat-boosts [{:sender "fiat-user"
+                                 :total 1000
+                                 :count 1
+                                 :boosts [{:boostagram/sender_name_normalized "fiat-user"
+                                           :boostagram/amount_fiat_cents 1000
+                                           :boostagram/amount_fiat_currency "USD"
+                                           :boostagram/payment_rail "card"
+                                           :boostagram/podcast "LINUX Unplugged"
+                                           :boostagram/episode "Fiat Ep"
+                                           :boostagram/app_name "Zaprite"
+                                           :boostagram/message "Card payment!"
+                                           :invoice/creation_date 2000000015
+                                           :invoice/created_at now
+                                           :scraper/source "zaprite"}]}]
+                  :member-free-boosts [{:sender "free-user"
+                                        :count 1
+                                        :boosts [{:boostagram/sender_name_normalized "free-user"
+                                                  :boostagram/payment_rail "member-free"
+                                                  :boostagram/memberful_member_id "42"
+                                                  :boostagram/podcast "LINUX Unplugged"
+                                                  :boostagram/episode "Free Ep"
+                                                  :boostagram/message "Free boost!"
+                                                  :invoice/creation_date 2000000020
+                                                  :invoice/created_at now
+                                                  :scraper/source "r2-member"}]}]
+                  :boost-summary {:boost_total_sats 60500
+                                  :boost_total_boosts 3
+                                  :boost_total_boosters 3}
+                  :stream-summary {:stream_total_sats 0
+                                   :stream_total_streams 0
+                                   :stream_total_streamers 0}
+                  :summary {:total_sats 60500
+                            :total_invoices 5
+                            :total_unique_boosters 5
+                            :last_seen_id 42}}
+          output (reports/format-sorted-report sorted)]
+      (is (str/includes? output "## Baller Boosts"))
+      (is (str/includes? output "## Boosts"))
+      (is (str/includes? output "## Thanks"))
+      (is (str/includes? output "## Fiat Boosts"))
+      (is (str/includes? output "## Member Free Boosts"))
+      (is (str/includes? output "## Boost Summary"))
+      (is (str/includes? output "## Stream Summary"))
+      (is (str/includes? output "## Summary"))
+      (is (str/includes? output "## Last Seen"))
+      (is (str/includes? output "big-spender"))
+      (is (str/includes? output "50,000 sats"))
+      (is (str/includes? output "fiat-user"))
+      (is (str/includes? output "$10.00 (card)"))
+      (is (str/includes? output "free-user"))
+      (is (str/includes? output "Free Member Boost"))
+      (is (str/includes? output "Total Boosted Sats: 60,500"))
+      (is (str/includes? output "Total Sats: 60,500"))
+      (is (str/includes? output "Total Fiat Boosts: 1 (1 booster)"))
+      (is (str/includes? output "Total Member Free Boosts: 1 (1 member)"))
+      (is (str/includes? output "Last seen ID: 42")))))
+
+(deftest test-format-sorted-report-empty-sections
+  (testing "empty fiat-boosts and member-free-boosts omit their sections"
+    (let [sorted {:ballers []
+                  :boosts []
+                  :thanks []
+                  :fiat-boosts []
+                  :member-free-boosts []
+                  :boost-summary {:boost_total_sats 0
+                                  :boost_total_boosts 0
+                                  :boost_total_boosters 0}
+                  :stream-summary {:stream_total_sats 0
+                                   :stream_total_streams 0
+                                   :stream_total_streamers 0}
+                  :summary {:total_sats 0
+                            :total_invoices 0
+                            :total_unique_boosters 0
+                            :last_seen_id nil}}
+          output (reports/format-sorted-report sorted)]
+      (is (str/includes? output "## Baller Boosts"))
+      (is (str/includes? output "## Boosts"))
+      (is (str/includes? output "## Thanks"))
+      (is (str/includes? output "## Boost Summary"))
+      (is (str/includes? output "## Stream Summary"))
+      (is (str/includes? output "## Summary"))
+      (is (str/includes? output "## Last Seen"))
+      (is (not (str/includes? output "## Fiat Boosts")))
+      (is (not (str/includes? output "## Member Free Boosts")))
+      (is (not (str/includes? output "Total Fiat Boosts")))
+      (is (not (str/includes? output "Total Member Free Boosts")))
+      (is (str/includes? output "Total Boosted Sats: 0"))
+      (is (str/includes? output "Last seen ID: ")))))
+
+(deftest test-format-sorted-report-partial-sections
+  (testing "fiat-boosts present, member-free absent (and vice versa)"
+    (let [now (java.util.Date.)
+          fiat-result (reports/format-sorted-report
+                       {:ballers []
+                        :boosts []
+                        :thanks []
+                        :fiat-boosts [{:sender "fiat-only"
+                                       :total 500
+                                       :count 1
+                                       :boosts [{:boostagram/sender_name_normalized "fiat-only"
+                                                 :boostagram/amount_fiat_cents 500
+                                                 :boostagram/amount_fiat_currency "USD"
+                                                 :boostagram/payment_rail "card"
+                                                 :boostagram/message "Fiat only"
+                                                 :invoice/creation_date 2000000000
+                                                 :invoice/created_at now}]}]
+                        :member-free-boosts []
+                        :boost-summary {:boost_total_sats 0 :boost_total_boosts 0 :boost_total_boosters 0}
+                        :stream-summary {:stream_total_sats 0 :stream_total_streams 0 :stream_total_streamers 0}
+                        :summary {:total_sats 0 :total_invoices 1 :total_unique_boosters 1 :last_seen_id 1}})
+          free-result (reports/format-sorted-report
+                       {:ballers []
+                        :boosts []
+                        :thanks []
+                        :fiat-boosts []
+                        :member-free-boosts [{:sender "free-only"
+                                              :count 1
+                                              :boosts [{:boostagram/sender_name_normalized "free-only"
+                                                        :boostagram/payment_rail "member-free"
+                                                        :boostagram/message "Free only"
+                                                        :invoice/creation_date 2000000000
+                                                        :invoice/created_at now}]}]
+                        :boost-summary {:boost_total_sats 0 :boost_total_boosts 0 :boost_total_boosters 0}
+                        :stream-summary {:stream_total_sats 0 :stream_total_streams 0 :stream_total_streamers 0}
+                        :summary {:total_sats 0 :total_invoices 1 :total_unique_boosters 1 :last_seen_id 2}})]
+      (is (str/includes? fiat-result "## Fiat Boosts"))
+      (is (not (str/includes? fiat-result "## Member Free Boosts")))
+      (is (str/includes? fiat-result "Total Fiat Boosts: 1 (1 booster)"))
+      (is (not (str/includes? fiat-result "Total Member Free Boosts")))
+      (is (not (str/includes? free-result "## Fiat Boosts")))
+      (is (str/includes? free-result "## Member Free Boosts"))
+      (is (not (str/includes? free-result "Total Fiat Boosts")))
+      (is (str/includes? free-result "Total Member Free Boosts: 1 (1 member)")))))
+
+(deftest test-format-sorted-report-summary-lines
+  (testing "pluralization and counts with multiple senders"
+    (let [now (java.util.Date.)
+          sorted {:ballers []
+                  :boosts []
+                  :thanks []
+                  :fiat-boosts [{:sender "fiat1" :total 1000 :count 2
+                                 :boosts [{:boostagram/sender_name_normalized "fiat1"
+                                           :boostagram/amount_fiat_cents 500
+                                           :boostagram/amount_fiat_currency "USD"
+                                           :boostagram/payment_rail "card"
+                                           :invoice/creation_date 2000000000
+                                           :invoice/created_at now}
+                                          {:boostagram/sender_name_normalized "fiat1"
+                                           :boostagram/amount_fiat_cents 500
+                                           :boostagram/payment_rail "card"
+                                           :invoice/creation_date 2000000001
+                                           :invoice/created_at now}]}
+                                {:sender "fiat2" :total 500 :count 1
+                                 :boosts [{:boostagram/sender_name_normalized "fiat2"
+                                           :boostagram/amount_fiat_cents 500
+                                           :boostagram/amount_fiat_currency "USD"
+                                           :boostagram/payment_rail "card"
+                                           :invoice/creation_date 2000000002
+                                           :invoice/created_at now}]}
+                                {:sender "fiat3" :total 250 :count 1
+                                 :boosts [{:boostagram/sender_name_normalized "fiat3"
+                                           :boostagram/amount_fiat_cents 250
+                                           :boostagram/amount_fiat_currency "USD"
+                                           :boostagram/payment_rail "card"
+                                           :invoice/creation_date 2000000003
+                                           :invoice/created_at now}]}]
+                  :member-free-boosts [{:sender "free1" :count 3
+                                        :boosts (vec (repeat 3
+                                                             {:boostagram/sender_name_normalized "free1"
+                                                              :boostagram/payment_rail "member-free"
+                                                              :invoice/creation_date 2000000010
+                                                              :invoice/created_at now}))}
+                                       {:sender "free2" :count 2
+                                        :boosts (vec (repeat 2
+                                                             {:boostagram/sender_name_normalized "free2"
+                                                              :boostagram/payment_rail "member-free"
+                                                              :invoice/creation_date 2000000020
+                                                              :invoice/created_at now}))}]
+                  :boost-summary {:boost_total_sats 0 :boost_total_boosts 0 :boost_total_boosters 0}
+                  :stream-summary {:stream_total_sats 0 :stream_total_streams 0 :stream_total_streamers 0}
+                  :summary {:total_sats 0 :total_invoices 9 :total_unique_boosters 5 :last_seen_id 1}}
+          output (reports/format-sorted-report sorted)]
+      (is (str/includes? output "Total Fiat Boosts: 4 (3 boosters)"))
+      (is (str/includes? output "Total Member Free Boosts: 5 (2 members)"))))
+  (testing "single sender uses singular form"
+    (let [now (java.util.Date.)
+          sorted {:ballers []
+                  :boosts []
+                  :thanks []
+                  :fiat-boosts [{:sender "lonely" :total 100 :count 1
+                                 :boosts [{:boostagram/sender_name_normalized "lonely"
+                                           :boostagram/amount_fiat_cents 100
+                                           :boostagram/amount_fiat_currency "USD"
+                                           :boostagram/payment_rail "card"
+                                           :invoice/creation_date 2000000000
+                                           :invoice/created_at now}]}]
+                  :member-free-boosts [{:sender "solo" :count 1
+                                        :boosts [{:boostagram/sender_name_normalized "solo"
+                                                  :boostagram/payment_rail "member-free"
+                                                  :invoice/creation_date 2000000010
+                                                  :invoice/created_at now}]}]
+                  :boost-summary {:boost_total_sats 0 :boost_total_boosts 0 :boost_total_boosters 0}
+                  :stream-summary {:stream_total_sats 0 :stream_total_streams 0 :stream_total_streamers 0}
+                  :summary {:total_sats 0 :total_invoices 2 :total_unique_boosters 2 :last_seen_id 1}}
+          output (reports/format-sorted-report sorted)]
+      (is (str/includes? output "Total Fiat Boosts: 1 (1 booster)"))
+      (is (str/includes? output "Total Member Free Boosts: 1 (1 member)"))))
+  (testing "nil fiat-boosts and member-free-boosts — no crash, no lines"
+    (let [sorted {:ballers []
+                  :boosts []
+                  :thanks []
+                  :fiat-boosts nil
+                  :member-free-boosts nil
+                  :boost-summary {:boost_total_sats 0 :boost_total_boosts 0 :boost_total_boosters 0}
+                  :stream-summary {:stream_total_sats 0 :stream_total_streams 0 :stream_total_streamers 0}
+                  :summary {:total_sats 0 :total_invoices 0 :total_unique_boosters 0 :last_seen_id nil}}
+          output (reports/format-sorted-report sorted)]
+      (is (not (str/includes? output "Total Fiat Boosts")))
+      (is (not (str/includes? output "Total Member Free Boosts"))))))
+
+;; ============================================================================
+;; format-value-line edge cases
+;; ============================================================================
+
+(deftest test-format-value-line-edge-cases
+  (testing "large sats values get comma-separated"
+    (is (= "1,000,000 sats"
+           (reports/format-value-line {:boostagram/value_sat_total 1000000}))))
+  (testing "nil value_sat_total defaults to 0 sats"
+    (is (= "0 sats" (reports/format-value-line {}))))
+  (testing "0 fiat cents falls through to sats display"
+    (is (= "5,000 sats"
+           (reports/format-value-line {:boostagram/amount_fiat_cents 0
+                                       :boostagram/value_sat_total 5000}))))
+  (testing "fiat with nil payment_rail shows unknown"
+    (let [line (reports/format-value-line
+                {:boostagram/amount_fiat_cents 999
+                 :boostagram/payment_rail nil})]
+      (is (str/includes? line "$9.99"))
+      (is (str/includes? line "unknown"))))
+  (testing "fiat takes priority even with high sats value"
+    (let [line (reports/format-value-line
+                {:boostagram/amount_fiat_cents 2500
+                 :boostagram/value_sat_total 100000})]
+      (is (str/includes? line "$25.00"))
+      (is (not (str/includes? line "sats")))))
+  (testing "fiat value uses String/format (no comma separators)"
+    (let [line (reports/format-value-line
+                {:boostagram/amount_fiat_cents 1234567
+                 :boostagram/payment_rail "ach"})]
+      (is (str/includes? line "$12345.67"))
+      (is (str/includes? line "(ach)"))))
+  (testing "fiat precision at boundaries"
+    (is (str/includes?
+         (reports/format-value-line {:boostagram/amount_fiat_cents 1
+                                     :boostagram/payment_rail "card"})
+         "$0.01"))
+    (is (str/includes?
+         (reports/format-value-line {:boostagram/amount_fiat_cents 99
+                                     :boostagram/payment_rail "card"})
+         "$0.99"))))
+
+;; ============================================================================
+;; normalize-report: ReportsSchema with missing keys
+;; ============================================================================
+
+(deftest test-normalize-report-missing-keys
+  (testing "empty map returns defaults for vector keys, nil for map keys"
+    (let [result (reports/normalize-report {})]
+      ;; Vector keys have :default [] -- populated even when missing
+      (is (= [] (:ballers result)))
+      (is (= [] (:boosts result)))
+      (is (= [] (:thanks result)))
+      (is (= [] (:fiat-boosts result)))
+      (is (= [] (:member-free-boosts result)))
+      ;; Top-level map keys have no :default -- return nil when absent
+      (is (nil? (:boost-summary result)))
+      (is (nil? (:stream-summary result)))
+      (is (nil? (:summary result)))))
+
+  (testing "partial keys preserved, missing sub-keys get defaults within provided maps"
+    (let [result (reports/normalize-report
+                  {:ballers [{:sender "test" :total 50000}]
+                   :boost-summary {:boost_total_sats 5000}
+                   :summary {:total_sats 5000 :last_seen_id 42}})]
+      (is (= 1 (count (:ballers result))))
+      (is (empty? (:boosts result)))
+      (is (empty? (:thanks result)))
+      (is (empty? (:fiat-boosts result)))
+      (is (empty? (:member-free-boosts result)))
+      ;; Provided map keys are preserved
+      (is (= 5000 (:boost_total_sats (:boost-summary result))))
+      ;; Missing sub-keys within provided maps get defaults via schema
+      (is (= 0 (:boost_total_boosts (:boost-summary result))))
+      ;; stream-summary key not present in partial input
+      (is (nil? (:stream-summary result)))
+      ;; Provided summary map
+      (is (= 5000 (:total_sats (:summary result))))
+      (is (= 0 (:total_invoices (:summary result))))
+      (is (= 42 (:last_seen_id (:summary result))))))
+
+  (testing "boost-report output (all keys present) roundtrips through normalize"
+    (let [sorted {:ballers []
+                  :boosts []
+                  :thanks []
+                  :fiat-boosts []
+                  :member-free-boosts []
+                  :boost-summary {:boost_total_sats 100 :boost_total_boosts 2 :boost_total_boosters 2}
+                  :stream-summary {:stream_total_sats 50 :stream_total_streams 1 :stream_total_streamers 1}
+                  :summary {:total_sats 150 :total_invoices 3 :total_unique_boosters 3 :last_seen_id 99}}
+          normalized (reports/normalize-report sorted)]
+      (is (= 100 (:boost_total_sats (:boost-summary normalized))))
+      (is (= 50 (:stream_total_sats (:stream-summary normalized))))
+      (is (= 150 (:total_sats (:summary normalized))))
+      (is (= 99 (:last_seen_id (:summary normalized)))))))
+
+;; ============================================================================
+;; boost-report integration: full pipeline (query -> sort -> normalize -> format)
+;; These tests exercise the full pipeline with a real Datalevin connection.
+;; NOTE: get-boost-summary-for-report uses nested datalevin.core/q calls
+;; within the query. The basic path is verified below.
+;; ============================================================================
+
+(deftest test-boost-report-integration
+  (testing "full pipeline with real Datalevin query produces formatted report"
+    (let [tmpdir (str "/tmp/test-boost-report-int-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)
+          sat-epoch 2000000000
+          fiat-epoch 2000000001
+          free-epoch 2000000002]
+      (try
+        (d/transact! conn
+                     [{:invoice/identifier "b1"
+                       :boostagram/action "boost"
+                       :boostagram/type :sat
+                       :boostagram/sender_name_normalized "big-spender"
+                       :boostagram/value_sat_total 50000
+                       :boostagram/podcast "LINUX Unplugged"
+                       :boostagram/episode "Test Ep"
+                       :boostagram/app_name "Fountain"
+                       :boostagram/message "Baller boost!"
+                       :boostagram/ts 1000
+                       :invoice/creation_date sat-epoch
+                       :invoice/created_at (java.util.Date. 1000000)
+                       :boostagram/content_id "c1"
+                       :scraper/source "lnd"}
+                      {:invoice/identifier "b2"
+                       :boostagram/action "boost"
+                       :boostagram/type :fiat
+                       :boostagram/sender_name_normalized "fiat-user"
+                       :boostagram/value_sat_total 0
+                       :boostagram/amount_fiat_cents 2000
+                       :boostagram/amount_fiat_currency "USD"
+                       :boostagram/payment_rail "card"
+                       :boostagram/podcast "LINUX Unplugged"
+                       :boostagram/episode "Test Ep"
+                       :boostagram/app_name "Zaprite"
+                       :boostagram/message "Card boost"
+                       :invoice/creation_date fiat-epoch
+                       :invoice/created_at (java.util.Date. 2000000)
+                       :boostagram/content_id "c2"
+                       :scraper/source "zaprite"}
+                      {:invoice/identifier "b3"
+                       :boostagram/action "boost"
+                       :boostagram/type :member-free
+                       :boostagram/sender_name_normalized "free-user"
+                       :boostagram/value_sat_total 0
+                       :boostagram/payment_rail "member-free"
+                       :boostagram/memberful_member_id "42"
+                       :boostagram/podcast "LINUX Unplugged"
+                       :boostagram/episode "Test Ep"
+                       :boostagram/app_name "Memberful (Free)"
+                       :boostagram/message "Free boost"
+                       :invoice/creation_date free-epoch
+                       :invoice/created_at (java.util.Date. 3000000)
+                       :boostagram/content_id "c3"
+                       :scraper/source "r2-member"}])
+        (let [report-str (reports/boost-report conn #"LINUX Unplugged" 0)]
+          (is (str/includes? report-str "## Baller Boosts"))
+          (is (str/includes? report-str "## Fiat Boosts"))
+          (is (str/includes? report-str "## Member Free Boosts"))
+          (is (str/includes? report-str "## Boost Summary"))
+          (is (str/includes? report-str "## Stream Summary"))
+          (is (str/includes? report-str "## Summary"))
+          (is (str/includes? report-str "## Last Seen"))
+          (is (str/includes? report-str "big-spender"))
+          (is (str/includes? report-str "50,000 sats"))
+          (is (str/includes? report-str "$20.00 (card)"))
+          (is (str/includes? report-str "Free Member Boost"))
+          (is (str/includes? report-str "Total Boosted Sats: 50,000"))
+          (is (str/includes? report-str "Total Boosts: 1"))
+          (is (str/includes? report-str "Total Streamed Sats: 0"))
+          (is (str/includes? report-str "Last seen ID: 2000000002")))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+(deftest test-boost-report-integration-empty
+  (testing "empty report when no boosts match regex"
+    (let [tmpdir (str "/tmp/test-boost-report-int-empty-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)]
+      (try
+        (d/transact! conn
+                     [{:invoice/identifier "b1"
+                       :boostagram/action "boost"
+                       :boostagram/type :sat
+                       :boostagram/sender_name_normalized "user"
+                       :boostagram/value_sat_total 1000
+                       :boostagram/podcast "Other Show"
+                       :boostagram/episode "Ep"
+                       :boostagram/message "Wont match"
+                       :invoice/creation_date 1000
+                       :boostagram/content_id "c1"
+                       :scraper/source "lnd"}])
+        (let [report-str (reports/boost-report conn #"NONEXISTENT" 0)]
+          (is (str/includes? report-str "## Baller Boosts"))
+          (is (str/includes? report-str "## Boost Summary"))
+          (is (str/includes? report-str "Total Boosted Sats: 0"))
+          (is (not (str/includes? report-str "## Fiat Boosts")))
+          (is (not (str/includes? report-str "## Member Free Boosts"))))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+(deftest test-boost-report-integration-regex-matching
+  (testing "report matches by episode or podcast using re-matches (full string match)"
+    (let [tmpdir (str "/tmp/test-boost-report-regex-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)]
+      (try
+        (d/transact! conn
+                     ;; re-matches requires FULL string match.  Use exact values.
+                     [{:invoice/identifier "b1"
+                       :boostagram/action "boost"
+                       :boostagram/type :sat
+                       :boostagram/sender_name_normalized "user-a"
+                       :boostagram/value_sat_total 50000
+                       :boostagram/podcast "nope"
+                       :boostagram/episode "LUP 500" ;; exact match for #"LUP 500"
+                       :boostagram/app_name "Fountain"
+                       :boostagram/message "Episode match!"
+                       :invoice/creation_date 1000
+                       :boostagram/content_id "c1"
+                       :scraper/source "lnd"}
+                      {:invoice/identifier "b2"
+                       :boostagram/action "boost"
+                       :boostagram/type :sat
+                       :boostagram/sender_name_normalized "user-b"
+                       :boostagram/value_sat_total 3000
+                       :boostagram/podcast "LINUX Unplugged" ;; exact match for #"LINUX Unplugged"
+                       :boostagram/episode "nope"
+                       :boostagram/app_name "Podverse"
+                       :boostagram/message "Podcast match!"
+                       :invoice/creation_date 2000
+                       :boostagram/content_id "c2"
+                       :scraper/source "lnd"}
+                      {:invoice/identifier "b3"
+                       :boostagram/action "boost"
+                       :boostagram/type :sat
+                       :boostagram/sender_name_normalized "user-c"
+                       :boostagram/value_sat_total 1000
+                       :boostagram/podcast "Other Show"
+                       :boostagram/episode "Other Ep"
+                       :boostagram/app_name "Alby"
+                       :boostagram/message "Excluded"
+                       :invoice/creation_date 3000
+                       :boostagram/content_id "c3"
+                       :scraper/source "lnd"}])
+        (let [report-str (reports/boost-report conn #"LUP 500|LINUX Unplugged" 0)]
+          (is (str/includes? report-str "user-a") "episode-matched sender")
+          (is (str/includes? report-str "user-b") "podcast-matched sender")
+          (is (not (str/includes? report-str "user-c")) "non-matching sender excluded")
+          (is (str/includes? report-str "50,000 sats"))
+          (is (str/includes? report-str "3,000 sats")))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+;; ============================================================================
+;; first-booster: DB-dependent, finds earliest stream sender for an episode
+;; ============================================================================
+
+(deftest test-first-booster
+  (testing "returns earliest stream sender for an episode"
+    (let [tmpdir (str "/tmp/test-first-booster-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)]
+      (try
+        (d/transact! conn
+                     [{:invoice/identifier "s1"
+                       :boostagram/action "stream"
+                       :boostagram/episode "Ep1"
+                       :boostagram/sender_name "Alice"
+                       :boostagram/value_sat_total 1000
+                       :invoice/creation_date 100
+                       :boostagram/content_id "c1"
+                       :scraper/source "test"}
+                      {:invoice/identifier "s2"
+                       :boostagram/action "stream"
+                       :boostagram/episode "Ep1"
+                       :boostagram/sender_name "Bob"
+                       :boostagram/value_sat_total 2000
+                       :invoice/creation_date 200
+                       :boostagram/content_id "c2"
+                       :scraper/source "test"}
+                      ;; boost for same episode - must be excluded
+                      {:invoice/identifier "b1"
+                       :boostagram/action "boost"
+                       :boostagram/episode "Ep1"
+                       :boostagram/sender_name "Diana"
+                       :boostagram/value_sat_total 5000
+                       :invoice/creation_date 150
+                       :boostagram/content_id "c3"
+                       :scraper/source "test"}
+                      ;; stream for different episode - must be excluded
+                      {:invoice/identifier "s3"
+                       :boostagram/action "stream"
+                       :boostagram/episode "Ep2"
+                       :boostagram/sender_name "Eve"
+                       :boostagram/value_sat_total 4000
+                       :invoice/creation_date 50
+                       :boostagram/content_id "c4"
+                       :scraper/source "test"}])
+        (let [result (reports/first-booster conn "Ep1")]
+          (is (some? result))
+          (is (= "Alice" (:boostagram/sender_name result))))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+(deftest test-first-booster-empty
+  (testing "returns empty result when no streams match"
+    (let [tmpdir (str "/tmp/test-first-booster-empty-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)]
+      (try
+        (d/transact! conn
+                     [{:invoice/identifier "s1"
+                       :boostagram/action "stream"
+                       :boostagram/episode "Ep1"
+                       :boostagram/sender_name "Alice"
+                       :boostagram/value_sat_total 1000
+                       :invoice/creation_date 100
+                       :boostagram/content_id "c1"
+                       :scraper/source "test"}])
+        (let [result (reports/first-booster conn "NonExistentEp")]
+          (is (nil? result)))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+;; ============================================================================
+;; podcast-app-percentages: DB-dependent, calculates app share of boosts
+;; ============================================================================
+
+(deftest test-podcast-app-percentages
+  (testing "calculates correct percentages with and without app_name"
+    (let [tmpdir (str "/tmp/test-podcast-pct-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)]
+      (try
+        (d/transact! conn
+                     [{:invoice/identifier "b1"
+                       :boostagram/action "boost"
+                       :boostagram/app_name "Fountain"
+                       :boostagram/sender_name_normalized "user1"
+                       :boostagram/value_sat_total 1000
+                       :boostagram/content_id "c1"
+                       :scraper/source "test"}
+                      {:invoice/identifier "b2"
+                       :boostagram/action "boost"
+                       :boostagram/app_name "Fountain"
+                       :boostagram/sender_name_normalized "user2"
+                       :boostagram/value_sat_total 2000
+                       :boostagram/content_id "c2"
+                       :scraper/source "test"}
+                      ;; no app_name key at all -> get-else should return "unknown_app"
+                      {:invoice/identifier "b3"
+                       :boostagram/action "boost"
+                       :boostagram/sender_name_normalized "user3"
+                       :boostagram/value_sat_total 3000
+                       :boostagram/content_id "c3"
+                       :scraper/source "test"}
+                      ;; no app_name key at all -> get-else should return "unknown_app"
+                      {:invoice/identifier "b4"
+                       :boostagram/action "boost"
+                       :boostagram/sender_name_normalized "user4"
+                       :boostagram/value_sat_total 4000
+                       :boostagram/content_id "c4"
+                       :scraper/source "test"}])
+        (let [result (reports/podcast-app-percentages conn)
+              result-set (into #{} result)]
+          (is (= #{["Fountain" 50] ["unknown_app" 50]} result-set))
+          (is (= 2 (count result))))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+(deftest test-podcast-app-percentages-all-same-app
+  (testing "all boosts have the same app_name"
+    (let [tmpdir (str "/tmp/test-podcast-pct-same-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)]
+      (try
+        (d/transact! conn
+                     [{:invoice/identifier "b1"
+                       :boostagram/action "boost"
+                       :boostagram/app_name "Fountain"
+                       :boostagram/sender_name_normalized "user1"
+                       :boostagram/value_sat_total 1000
+                       :boostagram/content_id "c1"
+                       :scraper/source "test"}
+                      {:invoice/identifier "b2"
+                       :boostagram/action "boost"
+                       :boostagram/app_name "Fountain"
+                       :boostagram/sender_name_normalized "user2"
+                       :boostagram/value_sat_total 2000
+                       :boostagram/content_id "c2"
+                       :scraper/source "test"}])
+        (let [result (reports/podcast-app-percentages conn)]
+          (is (= [["Fountain" 100]] result)))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+(deftest test-podcast-app-percentages-all-unknown
+  (testing "all boosts lack app_name"
+    (let [tmpdir (str "/tmp/test-podcast-pct-unk-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)]
+      (try
+        (d/transact! conn
+                     [{:invoice/identifier "b1"
+                       :boostagram/action "boost"
+                       :boostagram/sender_name_normalized "user1"
+                       :boostagram/value_sat_total 1000
+                       :boostagram/content_id "c1"
+                       :scraper/source "test"}
+                      {:invoice/identifier "b2"
+                       :boostagram/action "boost"
+                       :boostagram/sender_name_normalized "user2"
+                       :boostagram/value_sat_total 2000
+                       :boostagram/content_id "c2"
+                       :scraper/source "test"}])
+        (let [result (reports/podcast-app-percentages conn)]
+          (is (= [["unknown_app" 100]] result)))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+(deftest test-podcast-app-percentages-only-streams
+  (testing "only stream records exist - no boosts at all"
+    (let [tmpdir (str "/tmp/test-podcast-pct-streams-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)]
+      (try
+        (d/transact! conn
+                     [{:invoice/identifier "s1"
+                       :boostagram/action "stream"
+                       :boostagram/app_name "Fountain"
+                       :boostagram/sender_name_normalized "user1"
+                       :boostagram/value_sat_total 1000
+                       :boostagram/content_id "c1"
+                       :scraper/source "test"}])
+        (let [result (reports/podcast-app-percentages conn)]
+          (is (empty? result)))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+(deftest test-add-fiat-to-total
+  (testing "nil rate — no conversion"
+    (let [report {:fiat-boosts [{:sender "user" :total 1500 :count 1 :boosts []}]
+                  :summary {:total_sats 0 :total_invoices 1 :total_unique_boosters 1}}
+          result (reports/add-fiat-to-total report nil)]
+      (is (= 0 (:total_sats (:summary result))))
+      (is (nil? (:fiat-converted result)))
+      (is (nil? (:fiat-skipped result)))))
+  (testing "nil rate with fiat — sets fiat-skipped"
+    (let [report {:fiat-boosts [{:sender "user" :total 1500 :count 1 :boosts []}]
+                  :summary {:total_sats 1000 :total_invoices 1 :total_unique_boosters 1}}
+          result (reports/add-fiat-to-total report {})]
+      (is (= 1000 (:total_sats (:summary result))))
+      (is (true? (:fiat-skipped result)))
+      (is (nil? (:fiat-converted result)))))
+  (testing "no fiat boosts — no conversion, no skipped"
+    (let [report {:fiat-boosts []
+                  :summary {:total_sats 1000 :total_invoices 1 :total_unique_boosters 1}}
+          result (reports/add-fiat-to-total report {:rate 50000 :source "test"})]
+      (is (= 1000 (:total_sats (:summary result))))
+      (is (nil? (:fiat-converted result)))
+      (is (nil? (:fiat-skipped result)))))
+  (testing "converts fiat cents to sats with source metadata"
+    (let [report {:fiat-boosts [{:sender "user" :total 1500 :count 1 :boosts []}]
+                  :summary {:total_sats 0 :total_invoices 1 :total_unique_boosters 1}}
+          result (reports/add-fiat-to-total report {:rate 50000 :source "test"})]
+      (is (= 750000 (:total_sats (:summary result))))
+      (is (= "test" (-> result :fiat-converted :source)))
+      (is (= 50000 (-> result :fiat-converted :rate)))))
+  (testing "adds to existing sats total"
+    (let [report {:fiat-boosts [{:sender "user" :total 500 :count 1 :boosts []}]
+                  :summary {:total_sats 100000 :total_invoices 2 :total_unique_boosters 2}}
+          result (reports/add-fiat-to-total report {:rate 50000 :source "test"})]
+      (is (= 350000 (:total_sats (:summary result))))))
+  (testing "multiple fiat senders summed"
+    (let [report {:fiat-boosts [{:sender "a" :total 1000 :count 1 :boosts []}
+                                {:sender "b" :total 2000 :count 1 :boosts []}]
+                  :summary {:total_sats 0 :total_invoices 2 :total_unique_boosters 2}}
+          result (reports/add-fiat-to-total report {:rate 20000 :source "test"})]
+      (is (= 600000 (:total_sats (:summary result)))))))
+
+;; ============================================================================
+;; source-breakdown: per-source aggregation
+;; ============================================================================
+
+(deftest test-sort-report-source-breakdown
+  (testing "source breakdown merges sat/fiat/member-free results per source"
+    (let [sat-results [["lnd" 50000 3] ["nodecan" 10000 1]]
+          fiat-results [["zaprite" 3000 2]]
+          member-results [["r2-member" 5]]
+          raw [[] [] [] [] []
+               [0 0 0] [0 0 0] [0 0 0] nil
+               sat-results fiat-results member-results]
+          result (reports/sort-report raw)
+          sb (:source-breakdown result)]
+      (is (= 4 (count sb)))
+      (is (= 3 (:count (get sb "lnd"))))
+      (is (= 50000 (:sats (get sb "lnd"))))
+      (is (= 0 (:fiat-cents (get sb "lnd"))))
+      (is (= 1 (:count (get sb "nodecan"))))
+      (is (= 10000 (:sats (get sb "nodecan"))))
+      (is (= 2 (:count (get sb "zaprite"))))
+      (is (= 3000 (:fiat-cents (get sb "zaprite"))))
+      (is (= 0 (:sats (get sb "zaprite"))))
+      (is (= 5 (:count (get sb "r2-member")))))))
+
+(deftest test-format-sorted-report-source-breakdown
+  (testing "renders source breakdown section with counts, sats, and fiat"
+    (let [sorted {:ballers []
+                  :boosts []
+                  :thanks []
+                  :fiat-boosts []
+                  :member-free-boosts []
+                  :boost-summary {:boost_total_sats 0 :boost_total_boosts 0 :boost_total_boosters 0}
+                  :stream-summary {:stream_total_sats 0 :stream_total_streams 0 :stream_total_streamers 0}
+                  :summary {:total_sats 0 :total_invoices 0 :total_unique_boosters 0 :last_seen_id 1}
+                  :source-breakdown {"lnd" {:count 5 :sats 60000 :fiat-cents 0}
+                                     "zaprite" {:count 2 :sats 0 :fiat-cents 3500}
+                                     "r2-member" {:count 1 :sats 0 :fiat-cents 0}}}
+          output (reports/format-sorted-report sorted)]
+      (is (str/includes? output "## Source Breakdown"))
+      (is (str/includes? output "lnd: 5 boosts — 60,000 sats"))
+      (is (str/includes? output "zaprite: 2 boosts — 0 sats, $35.00 fiat"))
+      (is (str/includes? output "r2-member: 1 boost — 0 sats")))))
+
+(deftest test-boost-report-integration-source-breakdown
+  (testing "full pipeline with multiple sources produces source breakdown in report"
+    (let [tmpdir (str "/tmp/test-boost-report-src-" (java.util.UUID/randomUUID))
+          conn (d/get-conn tmpdir db/schema)]
+      (try
+        (d/transact! conn
+                     [{:invoice/identifier "b1"
+                       :boostagram/action "boost"
+                       :boostagram/type :sat
+                       :boostagram/sender_name_normalized "user1"
+                       :boostagram/value_sat_total 50000
+                       :boostagram/podcast "LINUX Unplugged"
+                       :boostagram/episode "Ep1"
+                       :boostagram/app_name "Fountain"
+                       :boostagram/message "Sat boost"
+                       :invoice/creation_date 2000000000
+                       :invoice/created_at (java.util.Date. 1000000)
+                       :boostagram/content_id "c1"
+                       :scraper/source "lnd"}
+                      {:invoice/identifier "b2"
+                       :boostagram/action "boost"
+                       :boostagram/type :sat
+                       :boostagram/sender_name_normalized "user2"
+                       :boostagram/value_sat_total 3000
+                       :boostagram/podcast "LINUX Unplugged"
+                       :boostagram/episode "Ep1"
+                       :boostagram/app_name "Alby"
+                       :boostagram/message "Sat boost 2"
+                       :invoice/creation_date 2000000001
+                       :invoice/created_at (java.util.Date. 2000000)
+                       :boostagram/content_id "c2"
+                       :scraper/source "nodecan"}
+                      {:invoice/identifier "b3"
+                       :boostagram/action "boost"
+                       :boostagram/type :fiat
+                       :boostagram/sender_name_normalized "user3"
+                       :boostagram/value_sat_total 0
+                       :boostagram/amount_fiat_cents 5000
+                       :boostagram/amount_fiat_currency "USD"
+                       :boostagram/payment_rail "card"
+                       :boostagram/podcast "LINUX Unplugged"
+                       :boostagram/episode "Ep1"
+                       :boostagram/app_name "Zaprite"
+                       :boostagram/message "Fiat boost"
+                       :invoice/creation_date 2000000002
+                       :invoice/created_at (java.util.Date. 3000000)
+                       :boostagram/content_id "c3"
+                       :scraper/source "zaprite"}])
+        (let [report-str (reports/boost-report conn #"LINUX Unplugged" 0)]
+          (is (str/includes? report-str "## Source Breakdown"))
+          (is (str/includes? report-str "lnd:"))
+          (is (str/includes? report-str "nodecan:"))
+          (is (str/includes? report-str "zaprite:")))
+        (finally
+          (d/close conn)
+          (test-utils/delete-dir-recursively (io/file tmpdir)))))))
+
+

--- a/test/boost_scraper/test_utils.clj
+++ b/test/boost_scraper/test_utils.clj
@@ -1,0 +1,11 @@
+(ns boost-scraper.test-utils
+  (:require [clojure.java.io :as io]))
+
+(defn delete-dir-recursively
+  "Delete a directory and all its contents recursively."
+  [f]
+  (doseq [child (.listFiles (io/file f))]
+    (if (.isDirectory child)
+      (delete-dir-recursively child)
+      (io/delete-file child :silently)))
+  (io/delete-file f :silently))

--- a/test/boost_scraper/upstream_test.clj
+++ b/test/boost_scraper/upstream_test.clj
@@ -1,0 +1,473 @@
+(ns boost-scraper.upstream-test
+  (:require [cheshire.core :as json]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [boost-scraper.db :as db]
+            [boost-scraper.reports :as reports]
+            [boost-scraper.upstream.zaprite :as zaprite]
+            [boost-scraper.upstream.r2 :as r2]))
+
+(deftest test-format-value-line
+  (testing "sats-based boost"
+    (is (= "1,234 sats"
+           (reports/format-value-line {:boostagram/value_sat_total 1234}))))
+  (testing "nil value_sat_total defaults to 0 sats"
+    (is (= "0 sats"
+           (reports/format-value-line {}))))
+  (testing "fiat boost (USD card)"
+    (let [line (reports/format-value-line
+                {:boostagram/amount_fiat_cents 500
+                 :boostagram/amount_fiat_currency "USD"
+                 :boostagram/payment_rail "card"})]
+      (is (str/includes? line "$5.00"))
+      (is (str/includes? line "card"))))
+  (testing "fiat boost (ACH)"
+    (let [line (reports/format-value-line
+                {:boostagram/amount_fiat_cents 1999
+                 :boostagram/amount_fiat_currency "USD"
+                 :boostagram/payment_rail "ach"})]
+      (is (str/includes? line "$19.99"))
+      (is (str/includes? line "ach"))))
+  (testing "member-free boost"
+    (is (= "Free Member Boost"
+           (reports/format-value-line
+            {:boostagram/payment_rail "member-free"
+             :boostagram/value_sat_total 0}))))
+  (testing "fiat takes priority over sats"
+    (let [line (reports/format-value-line
+                {:boostagram/amount_fiat_cents 1000
+                 :boostagram/amount_fiat_currency "USD"
+                 :boostagram/payment_rail "card"
+                 :boostagram/value_sat_total 50000})]
+      (is (str/includes? line "$10.00"))
+      (is (not (str/includes? line "sats")))))
+  (testing "0-cent fiat treated as sats (consistent with boost-type)"
+    (is (= "0 sats"
+           (reports/format-value-line
+            {:boostagram/amount_fiat_cents 0
+             :boostagram/payment_rail "card"
+             :boostagram/value_sat_total 0})))))
+
+(deftest test-infer-payment-rail
+  (testing "lightning"
+    (is (= "lightning" (zaprite/infer-payment-rail {:transactions [{:method "LIGHTNING"}]}))))
+  (testing "card"
+    (is (= "card" (zaprite/infer-payment-rail {:transactions [{:method "CARD"}]}))))
+  (testing "apple pay maps to card"
+    (is (= "card" (zaprite/infer-payment-rail {:transactions [{:method "APPLEPAY"}]}))))
+  (testing "unknown method lowercased"
+    (is (= "crypto" (zaprite/infer-payment-rail {:transactions [{:method "CRYPTO"}]}))))
+  (testing "no transactions returns unknown"
+    (is (= "unknown" (zaprite/infer-payment-rail {})))))
+
+(deftest test-process-order
+  (testing "BTC order"
+    (let [order {:id "ord-123"
+                 :totalAmount 10000
+                 :currency "BTC"
+                 :paidAt "2026-05-26T12:00:00.000Z"
+                 :transactions [{:method "LIGHTNING"}]
+                 :metadata {:app "web-boost" :podcastName "LINUX Unplugged" :episodeTitle "Test Episode" :username "testuser" :message "Great show!" :memberId 42 :slug "lup"}}
+          entity (zaprite/process-order order)]
+      (is (= "zaprite-ord-123" (:invoice/identifier entity)))
+      (is (= "LINUX Unplugged" (:boostagram/podcast entity)))
+      (is (= 10000 (:boostagram/value_sat_total entity)))
+      (is (nil? (:boostagram/amount_fiat_cents entity)))
+      (is (nil? (:boostagram/amount_fiat_currency entity)))
+      (is (= "lightning" (:boostagram/payment_rail entity)))
+      (is (= "zaprite" (:scraper/source entity)))
+      (is (= "testuser" (:boostagram/sender_name entity)))
+      (is (= "42" (:boostagram/memberful_member_id entity)))
+      (is (= "lup" (:boostagram/podcast_slug entity)))
+      (is (= :sat (:boostagram/type entity)))))
+  (testing "USD order via card"
+    (let [order {:id "ord-456"
+                 :totalAmount 500
+                 :currency "USD"
+                 :paidAt "2026-05-26T13:00:00.000Z"
+                 :transactions [{:method "CARD"}]
+                 :metadata {:app "web-boost"
+                            :podcastName "Self-Hosted"
+                            :episodeTitle "Test Episode 2"
+                            :username "fiat-user"
+                            :message "Paying with card!"}}
+          entity (zaprite/process-order order)]
+      (is (= "zaprite-ord-456" (:invoice/identifier entity)))
+      (is (= 0 (:boostagram/value_sat_total entity)))
+      (is (= 500 (:boostagram/amount_fiat_cents entity)))
+      (is (= "USD" (:boostagram/amount_fiat_currency entity)))
+      (is (= "card" (:boostagram/payment_rail entity)))
+      (is (= "zaprite" (:scraper/source entity)))
+      (is (= :fiat (:boostagram/type entity)))))
+  (testing "no metadata (non-web-boost) — still processes with defaults"
+    (let [order {:id "ord-789"
+                 :totalAmount 2000
+                 :currency "BTC"
+                 :paidAt "2026-05-26T14:00:00.000Z"
+                 :transactions [{:method "LIGHTNING"}]}
+          entity (zaprite/process-order order)]
+      (is (= "zaprite-ord-789" (:invoice/identifier entity)))
+      (is (nil? (:boostagram/podcast entity)))
+      (is (= "" (:boostagram/message entity)))))
+  (testing "missing paidAt — gracefully handles nil date"
+    (let [order {:id "ord-nil-date"
+                 :totalAmount 5000
+                 :currency "BTC"
+                 :transactions [{:method "LIGHTNING"}]
+                 :metadata {:app "web-boost"}}
+          entity (zaprite/process-order order)]
+      (is (= "zaprite-ord-nil-date" (:invoice/identifier entity)))
+      (is (nil? (:invoice/creation_date entity)))
+      (is (nil? (:invoice/created_at entity)))
+      (is (nil? (:boostagram/received_at entity))))))
+
+(deftest test-process-order-slug-fallback
+  (testing "podcastSlug used when slug not present in metadata"
+    (let [order {:id "ord-slug-fallback"
+                 :totalAmount 1000
+                 :currency "BTC"
+                 :paidAt "2026-05-26T20:00:00.000Z"
+                 :transactions [{:method "LIGHTNING"}]
+                 :metadata {:app "web-boost"
+                            :podcastName "Self-Hosted"
+                            :podcastSlug "selfh"
+                            :episodeTitle "Test"
+                            :username "user"
+                            :message "hi"}}
+          entity (zaprite/process-order order)]
+      (is (= "selfh" (:boostagram/podcast_slug entity)))
+      (is (= "Self-Hosted" (:boostagram/podcast entity)))))
+  (testing "slug takes priority over podcastSlug"
+    (let [order {:id "ord-slug-priority"
+                 :totalAmount 1000
+                 :currency "BTC"
+                 :paidAt "2026-05-26T21:00:00.000Z"
+                 :transactions [{:method "LIGHTNING"}]
+                 :metadata {:app "web-boost"
+                            :podcastName "Test Show"
+                            :slug "winner"
+                            :podcastSlug "loser"
+                            :episodeTitle "Test"
+                            :username "user"
+                            :message "hi"}}
+          entity (zaprite/process-order order)]
+      (is (= "winner" (:boostagram/podcast_slug entity)))))
+  (testing "neither slug nor podcastSlug — nil"
+    (let [order {:id "ord-no-slug"
+                 :totalAmount 1000
+                 :currency "BTC"
+                 :paidAt "2026-05-26T22:00:00.000Z"
+                 :transactions [{:method "LIGHTNING"}]
+                 :metadata {:app "web-boost"}}
+          entity (zaprite/process-order order)]
+      (is (nil? (:boostagram/podcast_slug entity))))))
+
+(deftest test-process-record
+  (testing "member free boost with full 10-field record"
+    (let [record {:boostId "boost-abc"
+                  :username "free-user"
+                  :message "Thanks for the show!"
+                  :createdAt "2026-05-26T14:00:00.000Z"
+                  :memberId 9012
+                  :podcastSlug "lup"
+                  :podcastName "Linux Unplugged"
+                  :episodeGuid "guid-456"
+                  :episodeTitle "The Config Episode"
+                  :amountFiatCents 0
+                  :amountFiatCurrency "USD"}
+          object-key "member-boosts/v1/r/boost-abc.json"
+          entity (r2/process-record record object-key)]
+      (is (= object-key (:boostagram/r2_object_key entity)))
+      (is (= "member-r2-boost-abc" (:invoice/identifier entity)))
+      (is (= 0 (:boostagram/value_sat_total entity)))
+      (is (= "member-free" (:boostagram/payment_rail entity)))
+      (is (= "9012" (:boostagram/memberful_member_id entity)))
+      (is (= "Memberful (Free)" (:boostagram/app_name entity)))
+      (is (= "r2-member" (:scraper/source entity)))
+      (is (= "lup" (:boostagram/podcast_slug entity)))
+      (is (= "guid-456" (:boostagram/episode_guid entity)))
+      (is (= 0 (:boostagram/amount_fiat_cents entity)))
+      (is (= "USD" (:boostagram/amount_fiat_currency entity)))
+      (is (= "free-user" (:boostagram/sender_name entity)))
+      (is (= "Linux Unplugged" (:boostagram/podcast entity)))
+      (is (= "The Config Episode" (:boostagram/episode entity)))
+      (is (= :member-free (:boostagram/type entity)))))
+  (testing "missing memberId — nil when absent"
+    (let [record {:boostId "boost-no-member"
+                  :username "user"
+                  :createdAt "2026-05-26T15:00:00.000Z"
+                  :podcastSlug "test"
+                  :episodeGuid "guid-0"
+                  :amountFiatCents 0}
+          entity (r2/process-record record "key.json")]
+      (is (nil? (:boostagram/memberful_member_id entity)))))
+  (testing "non-zero fiat fields"
+    (let [record {:boostId "boost-paid"
+                  :username "paying-user"
+                  :message "worth it"
+                  :createdAt "2026-05-26T16:00:00.000Z"
+                  :memberId 555
+                  :podcastSlug "premium"
+                  :episodeGuid "guid-paid"
+                  :amountFiatCents 999
+                  :amountFiatCurrency "USD"}
+          entity (r2/process-record record "key.json")]
+      (is (= 999 (:boostagram/amount_fiat_cents entity)))
+      (is (= "USD" (:boostagram/amount_fiat_currency entity)))))
+  (testing "missing createdAt — nil date fields"
+    (let [record {:boostId "boost-no-date"
+                  :username "user"
+                  :podcastSlug "test"
+                  :episodeGuid "guid-nil"
+                  :amountFiatCents 0}
+          entity (r2/process-record record "key.json")]
+      (is (nil? (:invoice/creation_date entity)))
+      (is (nil? (:invoice/created_at entity)))
+      (is (nil? (:boostagram/received_at entity)))))
+  (testing "missing senderName — defaults to empty string"
+    (let [record {:boostId "boost-no-user"
+                  :createdAt "2026-05-26T17:00:00.000Z"
+                  :podcastSlug "test"
+                  :episodeGuid "guid-nil"
+                  :amountFiatCents 0}
+          entity (r2/process-record record "key.json")]
+      (is (= "" (:boostagram/sender_name_normalized entity)))
+      (is (= "" (:boostagram/message entity)))))
+  (testing "nil memberId (from JSON key missing) — nil attribute"
+    (let [record {:boostId "boost-no-member-id"
+                  :username "user"
+                  :createdAt "2026-05-26T18:00:00.000Z"
+                  :podcastSlug "test"
+                  :episodeGuid "guid-nil"
+                  :amountFiatCents 0}
+          entity (r2/process-record record "key.json")]
+      (is (nil? (:boostagram/memberful_member_id entity)))))
+  (testing "default currency when absent"
+    (let [record {:boostId "boost-no-currency"
+                  :username "user"
+                  :createdAt "2026-05-26T19:00:00.000Z"
+                  :podcastSlug "test"
+                  :episodeGuid "guid-nil"
+                  :amountFiatCents 0}
+          entity (r2/process-record record "key.json")]
+      (is (= "USD" (:boostagram/amount_fiat_currency entity))))))
+
+(deftest test-process-record-missing-podcast-episode
+  (testing "missing podcastName and episodeTitle — nil when absent"
+    (let [record {:boostId "boost-no-podcast"
+                  :username "user"
+                  :createdAt "2026-05-26T20:00:00.000Z"
+                  :podcastSlug "test"
+                  :episodeGuid "guid-nil"
+                  :amountFiatCents 0}
+          entity (r2/process-record record "key.json")]
+      (is (nil? (:boostagram/podcast entity)))
+      (is (nil? (:boostagram/episode entity))))))
+
+(deftest test-sort-report-with-fiat
+  (testing "fiat and sat boosts are separated into correct sections"
+    ;; Simulate the raw query output shape:
+    ;; [ballers boosts thanks [boost-summary] [stream-summary] [total-summary] last-seen-id]
+    (let [sat-boost {:boostagram/sender_name_normalized "big-spender"
+                     :boostagram/value_sat_total 50000
+                     :boostagram/podcast "LINUX Unplugged"
+                     :boostagram/episode "Test Ep"
+                     :boostagram/app_name "SomeApp"
+                     :invoice/creation_date 2000000000
+                     :scraper/source "lnd"}
+          fiat-boost {:boostagram/sender_name_normalized "fiat-user"
+                      :boostagram/value_sat_total 0
+                      :boostagram/amount_fiat_cents 1000
+                      :boostagram/amount_fiat_currency "USD"
+                      :boostagram/payment_rail "card"
+                      :boostagram/podcast "LINUX Unplugged"
+                      :boostagram/episode "Test Ep"
+                      :boostagram/app_name "Zaprite"
+                      :invoice/creation_date 2000000001
+                      :scraper/source "zaprite"}
+          member-free {:boostagram/sender_name_normalized "free-user"
+                       :boostagram/value_sat_total 0
+                       :boostagram/payment_rail "member-free"
+                       :boostagram/podcast "LINUX Unplugged"
+                       :boostagram/episode "Test Ep"
+                       :boostagram/app_name "Memberful (Free)"
+                       :invoice/creation_date 2000000002
+                       :scraper/source "r2-member"}
+          raw-result [[["big-spender" 50000 1 2000000000 [sat-boost]]]  ;; ballers
+                      []  ;; boosts
+                      []  ;; thanks
+                      [["fiat-user" 1000 1 [fiat-boost]]]  ;; fiat-by-sender
+                      [["free-user" 1 [member-free]]]  ;; member-free-by-sender
+                      [50000 1 1]  ;; boost-summary
+                      [0 0 0]  ;; stream-summary
+                      [50000 3 3]  ;; total-summary
+                      nil]  ;; last-seen-id
+          result (reports/sort-report raw-result)]
+      (is (= 1 (count (:ballers result))))
+      (is (= "big-spender" (-> result :ballers first :sender)))
+      (is (empty? (:boosts result)))
+      (is (empty? (:thanks result)))
+      (is (= 1 (count (:fiat-boosts result))))
+      (is (= "fiat-user" (-> result :fiat-boosts first :sender)))
+      (is (= 1000 (-> result :fiat-boosts first :total)))
+      (is (= 1 (count (:member-free-boosts result))))
+      (is (= "free-user" (-> result :member-free-boosts first :sender))))))
+
+(deftest test-process-order-keyword-roundtrip
+  (testing "json/parse-string true → process-order (production code path)"
+    (let [order-map {:id "ord-json-1" :totalAmount 5000 :currency "USD"
+                     :paidAt "2026-05-26T17:00:00.000Z"
+                     :transactions [{:method "CARD"}]
+                     :metadata {:app "web-boost" :podcastName "Test Show"
+                                :episodeTitle "Test Ep" :username "json-user"
+                                :message "from JSON"}}
+          json-string (json/generate-string order-map)
+          parsed (json/parse-string json-string true)
+          entity (zaprite/process-order parsed)]
+      (is (= "zaprite-ord-json-1" (:invoice/identifier entity)))
+      (is (= "Test Show" (:boostagram/podcast entity)))
+      (is (= 0 (:boostagram/value_sat_total entity)))
+      (is (= 5000 (:boostagram/amount_fiat_cents entity)))
+      (is (= "USD" (:boostagram/amount_fiat_currency entity)))
+      (is (= "card" (:boostagram/payment_rail entity))))))
+
+(deftest test-process-record-keyword-roundtrip
+  (testing "json/parse-string true → process-record (production code path)"
+    (let [record-map {:boostId "boost-json-1"
+                      :username "json-user"
+                      :message "from JSON"
+                      :createdAt "2026-05-26T18:00:00.000Z"
+                      :memberId 777
+                      :podcastSlug "lup"
+                      :podcastName "Linux Unplugged"
+                      :episodeGuid "guid-json"
+                      :episodeTitle "The Config Episode"
+                      :amountFiatCents 0
+                      :amountFiatCurrency "USD"}
+          json-string (json/generate-string record-map)
+          parsed (json/parse-string json-string true)
+          entity (r2/process-record parsed "member-boosts/v1/r/boost-json-1.json")]
+      (is (= "member-r2-boost-json-1" (:invoice/identifier entity)))
+      (is (= "json-user" (:boostagram/sender_name entity)))
+      (is (= "777" (:boostagram/memberful_member_id entity)))
+      (is (= "lup" (:boostagram/podcast_slug entity)))
+      (is (= "Linux Unplugged" (:boostagram/podcast entity)))
+      (is (= "The Config Episode" (:boostagram/episode entity))))))
+
+(deftest test-sort-report-boundaries
+  (testing "2000 sats lands in boosts section (not thanks)"
+    (let [now (java.util.Date.)
+          boost {:boostagram/sender_name_normalized "boundary-user"
+                 :boostagram/value_sat_total 2000
+                 :boostagram/podcast "Test Show"
+                 :boostagram/episode "Test Ep"
+                 :boostagram/app_name "App"
+                 :invoice/creation_date 2000000000
+                 :invoice/created_at now
+                 :scraper/source "lnd"}
+           raw [[]
+                [["boundary-user" 2000 1 2000000000 [boost]]]
+                []
+                []
+                []
+                [2000 1 1]
+                [0 0 0]
+                [2000 1 1]
+                nil]
+          result (reports/sort-report raw)]
+      (is (empty? (:ballers result)))
+      (is (= 1 (count (:boosts result))))
+      (is (empty? (:thanks result)))))
+  (testing "1999 sats lands in thanks section"
+    (let [now (java.util.Date.)
+          boost {:boostagram/sender_name_normalized "thanks-user"
+                 :boostagram/value_sat_total 1999
+                 :boostagram/podcast "Test Show"
+                 :boostagram/episode "Test Ep"
+                 :boostagram/app_name "App"
+                 :invoice/creation_date 2000000000
+                 :invoice/created_at now
+                 :scraper/source "lnd"}
+           raw [[]  ;; ballers
+                []  ;; boosts
+                [["thanks-user" 1999 1 2000000000 [boost]]]  ;; thanks
+                []  ;; fiat-by-sender
+                []  ;; member-free-by-sender
+                [1999 1 1]  ;; boost-summary
+                [0 0 0]  ;; stream-summary
+                [1999 1 1]  ;; total-summary
+                nil]  ;; last-seen-id
+          result (reports/sort-report raw)]
+      (is (empty? (:boosts result)))
+      (is (= 1 (count (:thanks result))))))
+  (testing "20000 sats lands in ballers section"
+    (let [now (java.util.Date.)
+          boost {:boostagram/sender_name_normalized "baller-user"
+                 :boostagram/value_sat_total 20000
+                 :boostagram/podcast "Test Show"
+                 :boostagram/episode "Test Ep"
+                 :boostagram/app_name "App"
+                 :invoice/creation_date 2000000000
+                 :invoice/created_at now
+                 :scraper/source "lnd"}
+          raw [[["baller-user" 20000 1 2000000000 [boost]]]
+               []
+               []
+               []
+               []
+               [20000 1 1]
+               [0 0 0]
+               [20000 1 1]
+               nil]
+          result (reports/sort-report raw)]
+      (is (= 1 (count (:ballers result))))
+      (is (empty? (:boosts result)))
+      (is (empty? (:thanks result)))))
+  (testing "empty results — all sections empty"
+    (let [raw [[] [] [] [] [] [0 0 0] [0 0 0] [0 0 0] nil]
+          result (reports/sort-report raw)]
+      (is (empty? (:ballers result)))
+      (is (empty? (:boosts result)))
+      (is (empty? (:thanks result)))
+      (is (empty? (:fiat-boosts result)))
+      (is (empty? (:member-free-boosts result))))))
+
+(deftest test-process-record-nil-free
+  (testing "process-record with missing amountFiatCents — no nil values after remove-empty-vals"
+    (let [record {:boostId "boost-no-fiat"
+                  :username "user"
+                  :createdAt "2026-05-26T18:00:00.000Z"
+                  :podcastSlug "test"
+                  :episodeGuid "guid-nil"}
+          entity (db/remove-empty-vals (r2/process-record record "key.json"))
+          nil-vals (filter (comp nil? val) entity)]
+      (is (empty? nil-vals) (str "nil values leaked: " nil-vals))))
+  (testing "process-record with all fields present — no nil values"
+    (let [record {:boostId "boost-full" :username "user" :message "hello"
+                  :createdAt "2026-05-26T18:00:00.000Z" :memberId 123
+                  :podcastSlug "test" :episodeGuid "guid-full"
+                  :podcastName "Test Show" :episodeTitle "Test Ep"
+                  :amountFiatCents 500 :amountFiatCurrency "USD"}
+          entity (db/remove-empty-vals (r2/process-record record "key.json"))
+          nil-vals (filter (comp nil? val) entity)]
+      (is (empty? nil-vals) (str "nil values leaked: " nil-vals)))))
+
+(deftest test-process-order-nil-free
+  (testing "BTC order — no nil values after remove-empty-vals"
+    (let [order {:id "ord-btc" :totalAmount 10000 :currency "BTC"
+                 :paidAt "2026-05-26T12:00:00.000Z"
+                 :transactions [{:method "LIGHTNING"}]
+                 :metadata {:app "web-boost" :podcastName "Test" :episodeTitle "Ep"
+                            :username "u" :message "m"}}
+          entity (db/remove-empty-vals (zaprite/process-order order))
+          nil-vals (filter (comp nil? val) entity)]
+      (is (empty? nil-vals) (str "nil values leaked: " nil-vals))))
+  (testing "USD order — no nil values after remove-empty-vals"
+    (let [order {:id "ord-usd" :totalAmount 500 :currency "USD"
+                 :paidAt "2026-05-26T12:00:00.000Z"
+                 :transactions [{:method "CARD"}]
+                 :metadata {:app "web-boost" :podcastName "Test" :episodeTitle "Ep"
+                            :username "u" :message "m"}}
+          entity (db/remove-empty-vals (zaprite/process-order order))
+          nil-vals (filter (comp nil? val) entity)]
+      (is (empty? nil-vals) (str "nil values leaked: " nil-vals)))))


### PR DESCRIPTION
Two new upstream data sources:

- **Zaprite**: paid boosts (fiat card/ACH, BTC Lightning). Paginated API
  polling with cursor tracking. Filters to web-boost app orders only.
- **R2 (Cloudflare)**: member-free boosts. S3 ListObjectsV2 + GetObject
  via SigV4 signing. Lex-order cursor from R2 object keys.

Both flow into nodecan-conn and appear in unified reports alongside
existing LND/Alby data.

Infrastructure:
- `with-retries` extracted to `utils.clj` (exponential backoff, full jitter)
- `aws-sigv4-sign` in `utils.clj` for R2 S3 access
- `check-http-status` in `utils.clj`, replaces duplicate per-scraper checks
- Clojure `deps.edn` replaces `bb.edn`; Nix flake for reproducible builds
- Remove legacy shell scripts and old GitHub Actions workflows

Schema:
- `:boostagram/type` keyword attribute (`:sat` / `:fiat` / `:member-free`),
  set at ingest in all three paths. Replaces re-derivation in sort-report.
- 12 additional attributes: payment rail, fiat amounts, R2 object keys,
  Zaprite order IDs, sync cursor tracking, member IDs, podcast/episode GUIDs.

Reports reworked:
- Fiat and member-free boosts get their own sections below sat-based tiers
  (ballers/boosts/thanks). `format-value-line` handles all three types.
- `sort-report` is a thin reshaper with no re-derivation logic — the query
  does the bucketing via type-filtered sub-queries.
- `?valid_eids` intentionally skips the type filter so `?last_seen_id`
  spans all boost types (documented inline).
- `first-booster`: two-step Datalog query — `(min ?timestamp)` to find
  earliest stream, then pull its details. No Clojure-side sorting.
- `podcast-app-percentages`: one Datalog query for per-app counts, then
  Clojure arithmetic for percentages.

Scrapers wired into `core.clj` scrape cycle as optional sources
(env-var gated, all off by default).

Backfill:
- `backfill-boost-type!` in `db.clj` sets `:boostagram/type :sat` on
  legacy entities that have `:boostagram/action` but no type. Called at
  startup, idempotent.

Tests: 51 tests, 377 assertions.
- `db_test.clj`: normalization, coercion, decoding, batch processing,
  6 backfill scenarios (empty DB, all-typed, mixed-types, no-action,
  existing-type-preserved, large-batch), schema roundtrip.
- `reports_test.clj` (new, 22 tests): sort-report all-positions/empty/mixed,
  format-sorted-report rendering, normalize-report edge cases, boost-report
  full pipeline integration with real Datalevin connections, first-booster,
  podcast-app-percentages (all-same, all-unknown, only-streams).
- `upstream_test.clj`: LND/Alby/Zaprite/R2 ingest with type assertions,
  9-element raw vectors for sort-report tests.
- `core_test.clj`: queue-based mock dispatch for scrape cycle.
- `api_test.clj`: HTTP API endpoint tests (gated behind TEST_BASE_URL).